### PR TITLE
default gitSha and insert main gitSha for distributed helm-chart

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -122,8 +122,8 @@ jobs:
 
       - name: run the tests
         run: |
-          # first substitute test enpoints in the test files
-          # TODO: pytest should be able to have a pattern for injection here but htis is quicker
+          # first substitute test endpoints in the test files
+          # TODO: pytest should be able to have a pattern for injection here but moving fast
           URL=$(minikube service vector --url)
           sed -i "s|vector_endpoint\=.*$|vector_endpoint\='$URL'|g" .github/workflows/tests/test_vector.py
           head -n 5 .github/workflows/tests/test_vector.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
           # create the index file
           helm repo index .
 
+          # update `values.yaml` with a gitSha
+          COMMITSHA=$(git rev-parse HEAD | cut -c1-10)
+          sed -i "s|gitSha: \"\"|gitSha: \"$COMMITSHA\"|g" "$helm-chart"/values.yaml
+
           git add -A
           chart_version=$(cat $chart/Chart.yaml| grep version: | cut -d' ' -f2)
           git commit -m $chart_version

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Once you have a k8s cluster set up you can `helm install` eoAPI as follows
    
       # add the required secret overrides to an arbitrarily named `.yaml` file (`config.yaml` below)
       $ cat config.yaml 
-      gitSha: "AB123"
       db:
         settings:
           secrets:

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -64,7 +64,9 @@ db:
 # "gcp" will be an option available in the future
 providerContext: "aws"
 
-gitSha: ""
+# if running `helm install` from repo directory you'll have to provide this
+# otherwise the chart on the gh-pages branch will provide the correct updated value
+gitSha: "gitshaABC123"
 
 service:
   port: 8080


### PR DESCRIPTION
## Available PR templates

<!--
  Github doesn't allow PR template selection the same way that it is possible with issues.
  Preview this and select the appropriate template
-->

- [Default](?expand=1&template=default.md)
- [Version Release](?expand=1&template=version_release.md)
- _Alternatively delete and start empty_
