### PR TITLE
Clarify pgstac initial database permissions.

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -91,23 +91,23 @@ jobs:
 
           exit $?
 
-      - name: debug pgstac-eoapiuser-permissions-upgrade job failure
+      - name: debug pgstac-eoapi-superuser-init-db job failure
         if: steps.helm-render-install-eoapi-templates.outcome == 'failure'
         continue-on-error: true
         run: |
-          echo "Extracting pgstac-eoapiuser-permissions-upgrade job info and logs for debugging..."
-          
+          echo "Extracting pgstac-eoapi-superuser-init-db job info and logs for debugging..."
+
           # Get job details
-          echo "===== pgstac-eoapiuser-permissions-upgrade Job Details ====="
-          kubectl get job pgstac-eoapiuser-permissions-upgrade -o yaml || echo "Could not get job details"
-          
+          echo "===== pgstac-eoapi-superuser-init-db Job Details ====="
+          kubectl get job pgstac-eoapi-superuser-init-db -o yaml || echo "Could not get job details"
+
           # Get pod details
           echo "===== Pod Details ====="
-          kubectl get pods --selector=app=pgstac-eoapiuser-permissions-upgrade -o wide || echo "Could not find pods"
-          
+          kubectl get pods --selector=app=pgstac-eoapi-superuser-init-db -o wide || echo "Could not find pods"
+
           # Extract logs from pods
           echo "===== Pod Logs ====="
-          PODS=$(kubectl get pods --selector=app=pgstac-eoapiuser-permissions-upgrade -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
+          PODS=$(kubectl get pods --selector=app=pgstac-eoapi-superuser-init-db -o jsonpath='{.items[*].metadata.name}' 2>/dev/null)
           if [ -n "$PODS" ]; then
             for POD in $PODS; do
               echo "--- Logs from pod $POD ---"
@@ -115,35 +115,35 @@ jobs:
               kubectl logs $POD || echo "Could not get logs from pod $POD"
             done
           else
-            echo "No pods found for pgstac-eoapiuser-permissions-upgrade job"
+            echo "No pods found for pgstac-eoapi-superuser-init-db job"
           fi
-          
+
           # Get pod descriptions for more details
           echo "===== Pod Descriptions ====="
-          kubectl describe pods --selector=app=pgstac-eoapiuser-permissions-upgrade || echo "Could not describe pods"
-          
+          kubectl describe pods --selector=app=pgstac-eoapi-superuser-init-db || echo "Could not describe pods"
+
           # Check the configmap contents
           echo "===== initdb ConfigMap Contents ====="
           kubectl get configmap initdb -o yaml || echo "Could not get initdb configmap"
-          
+
           # Check for any related events
           echo "===== Related Kubernetes Events ====="
-          kubectl get events | grep -E "pgstac-eoapiuser-permissions-upgrade|initdb" || echo "No relevant events found"
+          kubectl get events | grep -E "pgstac-eoapi-superuser-init-db|initdb" || echo "No relevant events found"
 
       - name: debug pgstac-migrate job failure
         if: steps.helm-render-install-eoapi-templates.outcome == 'failure'
         continue-on-error: true
         run: |
           echo "Extracting pgstac-migrate job info and logs for debugging..."
-          
+
           # Get job details
           echo "===== pgstac-migrate Job Details ====="
           kubectl get job pgstac-migrate -o yaml || echo "Could not get pgstac-migrate job details"
-          
+
           # Get pod details
           echo "===== pgstac-migrate Pod Details ====="
           kubectl get pods -l app=pgstac-migrate --all-namespaces || echo "Could not find pgstac-migrate pods"
-          
+
           # Extract logs from pgstac-migrate pod(s)
           echo "===== pgstac-migrate Pod Logs ====="
           echo "Looking for completed pods from pgstac-migrate job..."
@@ -157,14 +157,14 @@ jobs:
           else
             echo "No completed pods found for pgstac-migrate job"
           fi
-          
+
           # Get details about the database pods/services
           echo "===== Database Pod/Service Details ====="
           # Find database service
           kubectl get svc | grep "db" || echo "Could not find database services"
           # Find database pods
           kubectl get pods | grep "db-" || echo "Could not find database pods"
-          
+
           # Check for any events related to the job or pods
           echo "===== Related Kubernetes Events ====="
           kubectl get events | grep -E "pgstac|db" || echo "No relevant events found"
@@ -195,31 +195,31 @@ jobs:
         if: steps.watchservices.outcome == 'failure'
         run: |
           echo "The watchservices step failed or timed out. Extracting pod logs for debugging..."
-          
+
           # Get and display all pods status
           echo "===== Pod Status ====="
           kubectl get pods
-          
+
           # Extract logs from raster pod init container (wait-for-pgstacbootstrap)
           echo "===== Raster Pod Init Container Logs (wait-for-pgstacbootstrap) ====="
           kubectl get pod | grep "^raster-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} -c wait-for-pgstacbootstrap --tail=100 || echo "Could not get raster init container logs"
-          
+
           # Extract logs from raster pod main container
           echo "===== Raster Pod Main Container Logs ====="
           kubectl get pod | grep "^raster-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} --tail=100 || echo "Could not get raster main container logs"
-          
+
           # Extract logs from vector pod
           echo "===== Vector Pod Logs ====="
           kubectl get pod | grep "^vector-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} --tail=100 || echo "Could not get vector logs"
-          
+
           # Extract logs from stac pod
           echo "===== STAC Pod Logs ====="
           kubectl get pod | grep "^stac-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} --tail=100 || echo "Could not get STAC logs"
-          
+
           # Check if pods are in pending state or have issues
           echo "===== Pod Descriptions for Troubleshooting ====="
           kubectl get pod | grep "$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl describe pod/{} || echo "Could not describe pods"
-          
+
           # force GH action to show failed result
           exit 128
 
@@ -263,31 +263,31 @@ jobs:
         if: steps.testrunner.outcome == 'failure'
         run: |
           echo "The tests failed. Extracting pod logs for debugging..."
-          
+
           # Get and display all pods status
           echo "===== Pod Status ====="
           kubectl get pods
-          
+
           # Extract logs from raster pod init container (wait-for-pgstacbootstrap)
           echo "===== Raster Pod Init Container Logs (wait-for-pgstacbootstrap) ====="
           kubectl get pod | grep "^raster-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} -c wait-for-pgstacbootstrap --tail=100 || echo "Could not get raster init container logs"
-          
+
           # Extract logs from raster pod main container
           echo "===== Raster Pod Main Container Logs ====="
           kubectl get pod | grep "^raster-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} --tail=100 || echo "Could not get raster main container logs"
-          
+
           # Extract logs from vector pod
           echo "===== Vector Pod Logs ====="
           kubectl get pod | grep "^vector-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} --tail=100 || echo "Could not get vector logs"
-          
+
           # Extract logs from stac pod
           echo "===== STAC Pod Logs ====="
           kubectl get pod | grep "^stac-$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl logs pod/{} --tail=100 || echo "Could not get STAC logs"
-          
+
           # Check if pods are in pending state or have issues
           echo "===== Pod Descriptions for Troubleshooting ====="
           kubectl get pod | grep "$RELEASE_NAME" | cut -d' ' -f1 | xargs -I{} kubectl describe pod/{} || echo "Could not describe pods"
-          
+
           # force GH action to show failed result
           exit 128
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -96,7 +96,7 @@ helm list -n eoapi
 kubectl get pods -n eoapi
 
 # For subchart users, check the upgrade job status:
-kubectl get jobs -n eoapi | grep eoapiuser-permissions-upgrade
+kubectl get jobs -n eoapi | grep eoapi-superuser-init-db
 ```
 
 ### Troubleshooting
@@ -105,7 +105,7 @@ If you encounter issues during the upgrade:
 
 1. For subchart users, check the upgrade job logs:
 ```bash
-kubectl logs -n eoapi -l app=pgstac-eoapiuser-permissions-upgrade
+kubectl logs -n eoapi -l app=pgstac-eoapi-superuser-init-db
 ```
 
 2. Verify database permissions:

--- a/helm-chart/eoapi/templates/pgstacbootstrap/eoap-superuser-initdb.yaml
+++ b/helm-chart/eoapi/templates/pgstacbootstrap/eoap-superuser-initdb.yaml
@@ -1,25 +1,23 @@
 {{- if and .Values.postgrescluster.enabled .Values.pgstacBootstrap.enabled }}
 ---
-# This job is part of the upgrade process from pre-0.7.0 versions.
-# Prior to 0.7.0, database schema updates were run with superuser privileges.
-# This job ensures proper permissions are granted to the eoapi user during upgrade.
-# TODO: Remove with the next mayor verson and add to documentation that one needs to
-# through 0.7.x when upgrading.
+# The eoapi database user runs normally pgstac migrate.
+# But before some initial grants need to be given with a super user.
+# https://stac-utils.github.io/pgstac/pypgstac/#option-2-create-user-with-initial-grants
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: pgstac-eoapiuser-permissions-upgrade
+  name: pgstac-eoapi-superuser-init-db
   labels:
-    app: pgstac-eoapiuser-permissions-upgrade
+    app: pgstac-eoapi-superuser-init-db
   annotations:
-    helm.sh/hook: "post-upgrade"
+    helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "-7"
     helm.sh/hook-delete-policy: "before-hook-creation"
 spec:
   template:
     metadata:
       labels:
-        app: pgstac-eoapiuser-permissions-upgrade
+        app: pgstac-eoapi-superuser-init-db
     spec:
       restartPolicy: Never
       containers:
@@ -33,11 +31,9 @@ spec:
               # Exit immediately if a command exits with a non-zero status
               set -e
 
-              # Run permission setup with superuser
-              echo "Applying superuser permissions for upgrade from version {{ .Values.previousVersion }}..."
+              # Run the initial setup with superuser
               PGUSER=postgres psql -f /opt/sql/initdb.sql
 
-              echo "Permissions upgrade complete"
           resources:
             {{- toYaml .Values.pgstacBootstrap.settings.resources | nindent 12 }}
           volumeMounts:

--- a/helm-chart/eoapi/values.yaml
+++ b/helm-chart/eoapi/values.yaml
@@ -69,19 +69,19 @@ comment_db: >
 postgresql:
   # Management type: "postgrescluster" (default), "external-plaintext", or "external-secret"
   type: "postgrescluster"
-  
+
   # Configuration for external PostgreSQL (used when type is "external-plaintext" or "external-secret")
   external:
     # Connection information
     host: ""
     port: "5432"
     database: "eoapi"
-    
+
     # Credentials configuration (used when type is "external-plaintext")
     credentials:
       username: ""
       password: ""
-    
+
     # Secret reference (used when type is "external-secret")
     existingSecret:
       name: ""


### PR DESCRIPTION
Closes: https://github.com/developmentseed/eoapi-k8s/issues/234

There has been some confusion around permissions needed to set up the initial database for eoAPI. Instead of simplifying the setup (as tried here: https://github.com/developmentseed/eoapi-k8s/pull/238) let's rely on the setup as described in the [upstream documentation](https://stac-utils.github.io/pgstac/pypgstac/#option-2-create-user-with-initial-grants).