### PR TITLE
fix: Disable VRT support in TiTiler by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactors eoapi-support into core eoapi chart [#262](https://github.com/developmentseed/eoapi-k8s/pull/262)
 - Make integration tests fail properly
+- Temporarily skip VRT driver in GDALg to avoid https://github.com/OSGeo/gdal/issues/12645
 
 ## [0.7.13] - 2025-11-04
 

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -295,6 +295,7 @@ raster:
       GDAL_HTTP_MERGE_CONSECUTIVE_RANGES: "YES"
       GDAL_HTTP_MULTIPLEX: "YES"
       GDAL_HTTP_VERSION: "2"
+      GDAL_SKIP: "VRT" # skip VRT driver to avoid https://github.com/OSGeo/gdal/issues/12645
       PYTHONWARNINGS: "ignore"
       VSI_CACHE: "TRUE"
       VSI_CACHE_SIZE: "5000000"  # 5 MB (per file-handle)


### PR DESCRIPTION
Closes #242:

Skip VRT driver to prevent arbitrary file reading vulnerability reported in GDAL issue https://github.com/OSGeo/gdal/issues/12645 and https://github.com/developmentseed/titiler/issues/1180. This configuration prevents exploitation of GDAL's VRT driver which can be used to read arbitrary files from the filesystem.

Addresses https://github.com/developmentseed/eoapi-k8s/issues/242. But we might need additional precautions to prevent arbitrary filesystem access through other GDAL drivers.


