### PR TITLE
feat: add note on m1 mac issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ This will automatically:
 3. Install the eoAPI helm chart
 4. Set up necessary namespaces and configurations
 
+> [!WARNING]
+> Some images do not provide a `linux/arm64` compatible download (You may see image pull failures) which causes failures on M1 etc Macs, to get around this, you can pre-pull the image with:
+> ```
+> docker pull --platform=linux/amd64 <image>
+> minikube image load <image>
+> ```
+> You can then re-deploy the service and it will now use the local image.
+
+
 ### Option 2: Step-by-Step Installation
 
 If you prefer more control over the installation process:


### PR DESCRIPTION
# What this PR is

I experienced:

```
│   Warning  Failed   57m (x5 over 60m)     kubelet  Failed to pull image "ghcr.io/stac-utils/titiler-pgstac:1.7.1": no matching manifest for linux/arm64/v8 in the manifest list entries                                                                                                                │
```

When running `make minikube` locally, M1 Macs have issues handling non `arm64` compatible images. The note I added explains how to force this to work.
