### PR TITLE
feat: Add checksums to configmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Made existing context settings configurable (`context`, `context_estimated_count`, `context_estimated_cost`, `context_stats_ttl`)
   - Automatic queue processor CronJob created when `use_queue` is "true" (configurable schedule via `queueProcessor.schedule`)
   - Automatic extent updater CronJob created when `update_collection_extent` is "false" (configurable schedule via `extentUpdater.schedule`)
+- Added ConfigMap checksum annotations to automatically restart pods when configuration changes [#344](https://github.com/developmentseed/eoapi-k8s/pull/344)
 
 ### Changed
 

--- a/charts/eoapi/templates/services/multidim/deployment.yaml
+++ b/charts/eoapi/templates/services/multidim/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       app: {{ .Release.Name }}-multidim
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/services/multidim/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "eoapi.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: multidim

--- a/charts/eoapi/templates/services/raster/deployment.yaml
+++ b/charts/eoapi/templates/services/raster/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       app: {{ .Release.Name }}-raster
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/services/raster/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "eoapi.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: raster

--- a/charts/eoapi/templates/services/stac/deployment.yaml
+++ b/charts/eoapi/templates/services/stac/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       app: {{ .Release.Name }}-stac
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/services/stac/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "eoapi.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: stac

--- a/charts/eoapi/templates/services/vector/deployment.yaml
+++ b/charts/eoapi/templates/services/vector/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       app: {{ .Release.Name }}-vector
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/services/vector/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "eoapi.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: vector

--- a/charts/eoapi/tests/multidim_tests.yaml
+++ b/charts/eoapi/tests/multidim_tests.yaml
@@ -38,6 +38,20 @@ tests:
           path: metadata.labels.gitsha
           value: "ABC123"
 
+  - it: "multidim deployment includes configmap checksum annotation"
+    set:
+      multidim.enabled: true
+      stac.enabled: false
+      raster.enabled: false
+      vector.enabled: false
+    template: templates/services/multidim/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$
+
   - it: "multidim configmap defaults"
     set:
       raster.enabled: false

--- a/charts/eoapi/tests/raster_tests.yaml
+++ b/charts/eoapi/tests/raster_tests.yaml
@@ -34,6 +34,21 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: "3072Mi"
+
+  - it: "raster deployment includes configmap checksum annotation"
+    set:
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      gitSha: "ABC123"
+    template: templates/services/raster/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$
       - equal:
           path: metadata.labels.gitsha
           value: "ABC123"

--- a/charts/eoapi/tests/stac_tests.yaml
+++ b/charts/eoapi/tests/stac_tests.yaml
@@ -38,6 +38,20 @@ tests:
           path: metadata.labels.gitsha
           value: "ABC123"
 
+  - it: "stac deployment includes configmap checksum annotation"
+    set:
+      stac.enabled: true
+      raster.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+    template: templates/services/stac/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$
+
   - it: "stac configmap defaults"
     set:
       raster.enabled: false

--- a/charts/eoapi/tests/vector_tests.yaml
+++ b/charts/eoapi/tests/vector_tests.yaml
@@ -39,6 +39,20 @@ tests:
           path: metadata.labels.gitsha
           value: "ABC123"
 
+  - it: "vector deployment includes configmap checksum annotation"
+    set:
+      vector.enabled: true
+      stac.enabled: false
+      raster.enabled: false
+      multidim.enabled: false
+    template: templates/services/vector/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/config"]
+          pattern: ^[a-f0-9]{64}$
+
   - it: "vector configmap defaults"
     set:
       raster.enabled: false


### PR DESCRIPTION
Closes https://github.com/developmentseed/eoapi-k8s/issues/72

Makes eoAPI services auto-restart pods when ConfigMaps change. So far ConfigMap updates don't trigger pod restarts, requiring manual intervention.

This PR Adds a checksum annotations to Deployment pod templates. When ConfigMaps change, the checksum changes, triggering automatic rolling updates.

* Added checksum/config annotations to all Deployments using ConfigMaps
* Checksums computed via sha256sum of ConfigMap templates