### PR TITLE
fix: Name behavior field consistently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactors eoapi-support into core eoapi chart [#262](https://github.com/developmentseed/eoapi-k8s/pull/262)
 - Make integration tests fail properly
 - Temporarily skip VRT driver in GDALg to avoid https://github.com/OSGeo/gdal/issues/12645
+- Consistent naming of behavior field
 
 ## [0.7.13] - 2025-11-04
 

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -247,7 +247,7 @@ raster:
     maxReplicas: 10
     # `type`: "cpu" || "requestRate" || "both"
     type: "requestRate"
-    behaviour:
+    behavior:
       scaleDown:
         stabilizationWindowSeconds: 60
       scaleUp:
@@ -320,7 +320,7 @@ multidim:
     maxReplicas: 10
     # `type`: "cpu" || "requestRate" || "both"
     type: "requestRate"
-    behaviour:
+    behavior:
       scaleDown:
         stabilizationWindowSeconds: 60
       scaleUp:
@@ -392,7 +392,7 @@ stac:
     maxReplicas: 10
     # `type`: "cpu" || "requestRate" || "both"
     type: "requestRate"
-    behaviour:
+    behavior:
       scaleDown:
         stabilizationWindowSeconds: 60
       scaleUp:
@@ -452,7 +452,7 @@ vector:
     maxReplicas: 10
     # `type`: "cpu" || "requestRate" || "both"
     type: "requestRate"
-    behaviour:
+    behavior:
       scaleDown:
         stabilizationWindowSeconds: 60
       scaleUp:

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -61,7 +61,7 @@ stac:
     minReplicas: 2
     maxReplicas: 20
     type: "both"
-    behaviour:
+    behavior:
       scaleDown:
         stabilizationWindowSeconds: 300  # 5min cooldown
         policies:
@@ -147,7 +147,7 @@ raster:
     minReplicas: 2
     maxReplicas: 8
     type: "cpu"
-    behaviour:
+    behavior:
       scaleDown:
         stabilizationWindowSeconds: 300
     targets:
@@ -252,7 +252,7 @@ autoscaling:
   # Type can be "cpu", "requestRate", or "both"
   type: "cpu"
   # Custom scaling behavior (optional)
-  behaviour: {}
+  behavior: {}
   # Scaling targets
   targets:
     # CPU target percentage (when type is "cpu" or "both")
@@ -328,7 +328,7 @@ Adjust scaling behavior:
 
 ```yaml
 autoscaling:
-  behaviour:
+  behavior:
     scaleUp:
       stabilizationWindowSeconds: 60    # Faster scaling up
       policies:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,7 +218,7 @@ Fine-tune scaling behavior:
 
 ```yaml
 autoscaling:
-  behaviour:
+  behavior:
     scaleDown:
       stabilizationWindowSeconds: 60
     scaleUp:


### PR DESCRIPTION
Closes https://github.com/developmentseed/eoapi-k8s/issues/223

Introduces consistent naming of the `behavior` field. Chose the American English spelling to be consistent with Kubernetes' own behavior field.