### PR TITLE
fix: Helper for postgrescluster.enabled false when using external db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatic extent updater CronJob created when `update_collection_extent` is "false" (configurable schedule via `extentUpdater.schedule`)
 - Added ConfigMap checksum annotations to automatically restart pods when configuration changes [#344](https://github.com/developmentseed/eoapi-k8s/pull/344)
 - Tests for autoscaling
+- Added validation to require `postgrescluster.enabled: false` when using external databases [#346](https://github.com/developmentseed/eoapi-k8s/pull/346)
 
 ### Changed
 

--- a/charts/eoapi/README.md
+++ b/charts/eoapi/README.md
@@ -74,6 +74,7 @@ pgstacBootstrap:
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `postgresql.type` | Database deployment type | `postgrescluster` |
+| `postgrescluster.enabled` | Enable PostgreSQL cluster. Must be set to `false` when using external databases | `true` |
 | `ingress.enabled` | Enable ingress | `true` |
 | `ingress.className` | Ingress controller class | `nginx` |
 | `browser.enabled` | Enable STAC Browser interface | `true` |

--- a/charts/eoapi/templates/_helpers.tpl
+++ b/charts/eoapi/templates/_helpers.tpl
@@ -315,6 +315,9 @@ Validate PostgreSQL configuration
   {{- end }}
   {{- include "eoapi.validatePostgresCluster" . }}
 {{- else if eq .Values.postgresql.type "external-plaintext" }}
+  {{- if .Values.postgrescluster.enabled }}
+    {{- fail "When postgresql.type is 'external-plaintext', postgrescluster.enabled must be set to false" }}
+  {{- end }}
   {{- if not .Values.postgresql.external.host }}
     {{- fail "When postgresql.type is 'external-plaintext', postgresql.external.host must be set" }}
   {{- end }}
@@ -325,6 +328,9 @@ Validate PostgreSQL configuration
     {{- fail "When postgresql.type is 'external-plaintext', postgresql.external.credentials.password must be set" }}
   {{- end }}
 {{- else if eq .Values.postgresql.type "external-secret" }}
+  {{- if .Values.postgrescluster.enabled }}
+    {{- fail "When postgresql.type is 'external-secret', postgrescluster.enabled must be set to false" }}
+  {{- end }}
   {{- if not .Values.postgresql.external.existingSecret.name }}
     {{- fail "When postgresql.type is 'external-secret', postgresql.external.existingSecret.name must be set" }}
   {{- end }}

--- a/charts/eoapi/templates/validation.yaml
+++ b/charts/eoapi/templates/validation.yaml
@@ -1,0 +1,5 @@
+{{/*
+This template validates the PostgreSQL configuration.
+It doesn't create any resources but ensures configuration consistency.
+*/}}
+{{- include "eoapi.validatePostgresql" . }}

--- a/charts/eoapi/tests/postgres_tests.yaml
+++ b/charts/eoapi/tests/postgres_tests.yaml
@@ -68,3 +68,41 @@ tests:
               secretKeyRef:
                 name: test-release-pguser-my-user
                 key: user
+
+  - it: should fail when external-plaintext is used with postgrescluster enabled
+    set:
+      stac:
+        enabled: true
+      postgresql:
+        type: external-plaintext
+        external:
+          host: test-db
+          credentials:
+            username: test
+            password: test
+      postgrescluster:
+        enabled: true
+    template: templates/services/stac/deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: When postgresql.type is 'external-plaintext', postgrescluster.enabled must be set to false
+
+  - it: should fail when external-secret is used with postgrescluster enabled
+    set:
+      stac:
+        enabled: true
+      postgresql:
+        type: external-secret
+        external:
+          host: test-db
+          existingSecret:
+            name: my-secret
+            keys:
+              username: user
+              password: pass
+      postgrescluster:
+        enabled: true
+    template: templates/services/stac/deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: When postgresql.type is 'external-secret', postgrescluster.enabled must be set to false

--- a/charts/postgrescluster/templates/pgbackrest-secret.yaml
+++ b/charts/postgrescluster/templates/pgbackrest-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 {{- if or .Values.multiBackupRepos .Values.s3 .Values.gcs .Values.azure }}
 apiVersion: v1
 kind: Secret
@@ -22,7 +23,7 @@ data:
   azure.conf: |-
         {{ include "postgres.azure" $args | b64enc }}
   {{- end }}
-{{- end }}
+  {{- end }}
 {{- else if .Values.s3 }}
   {{- $args := dict "s3" .Values.s3 "index" 0 }}
   s3.conf: |-
@@ -37,5 +38,6 @@ data:
   {{- $args := dict "azure" .Values.azure "index" 0 }}
   azure.conf: |-
         {{ include "postgres.azure" $args | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/postgrescluster/templates/postgres.yaml
+++ b/charts/postgrescluster/templates/postgres.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enabled }}
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
@@ -227,3 +228,4 @@ spec:
   customReplicationTLSSecret:
 {{ toYaml .Values.customReplicationTLSSecret | indent 4 }}
   {{- end }}
+{{- end }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,18 +39,20 @@ Using Crunchydata's PostgreSQL Operator (`postgresql.type: "postgrescluster"`):
 
 | **Values Key** | **Description** | **Default** | **Choices** |
 |:--------------|:----------------|:------------|:------------|
-| `postgrescluster.enabled` | Enable PostgreSQL cluster | true | true/false |
+| `postgrescluster.enabled` | Enable PostgreSQL cluster. Must be set to `false` when using external databases | true | true/false |
 | `postgrescluster.name` | Cluster name | Release name | any valid k8s name |
 | `postgrescluster.postgresVersion` | PostgreSQL version | 16 | supported versions |
 | `postgrescluster.postGISVersion` | PostGIS version | "3.4" | supported versions |
 
 ### External Database
 
-For external databases, set `postgresql.type` to either:
+For external databases, set `postgresql.type` to either `external-plaintext` or `external-secret` and set `postgrescluster.enabled: false`.
 
 
 1. Using plaintext credentials (`external-plaintext`):
 ```yaml
+postgrescluster:
+  enabled: false
 postgresql:
   type: "external-plaintext"
   external:


### PR DESCRIPTION
Closes: https://github.com/developmentseed/eoapi-k8s/issues/224

Issue is to prevent PostgresCluster resources from being created when using external databases:

* Documented the requirement of setting this value.
* Added helper validation to require `postgrescluster.enabled: false` when `postgresql.type` is set to `external-plaintext` or `external-secret`, 
* Updated `postgrescluster` templates to properly respect the enabled flag