### PR TITLE
refactor: Simplify resource definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Removed all default resource specifications from values.yaml and profile files. Users must now explicitly set resource limits/requests based on their infrastructure needs. This simplifies the chart and acknowledges that resource requirements vary greatly based on workload and infrastructure. If you were relying on the default resource specifications, add them to your values override file:
+
+```yaml
+stac:
+  settings:
+    resources:
+      requests:
+        cpu: "512m"
+        memory: "1024Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+```
+
 ### Added
 
 - Expose PgSTAC configuration options in Helm chart values (`pgstacBootstrap.settings.pgstacSettings`). These are being dynamically applied via templated SQL during bootstrap.
@@ -30,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made all python tests comply with mypy strict validation
 - Improved documentation about access to grafana
 - Reorganized the helm chart templates files [#352](https://github.com/developmentseed/eoapi-k8s/pull/352)
+- Removed all default resource specifications from values.yaml
 
 ## [0.7.13] - 2025-11-04
 

--- a/charts/eoapi/README.md
+++ b/charts/eoapi/README.md
@@ -119,7 +119,32 @@ pgstacBootstrap:
 | `pgstacBootstrap.enabled` | Enable database initialization | `true` |
 | `notifications.sources.pgstac` | Enable PostgreSQL notification triggers for STAC item changes | `false` |
 
-Refer to the [values.schema.json](./values.schema.json) for the complete list of configurable parameters.
+### Resource Configuration
+
+This chart does not specify default resource limits/requests. Set resources based on your infrastructure and workload:
+
+```yaml
+# Example resource configuration in your values override
+stac:
+  settings:
+    resources:
+      requests:
+        cpu: "1"
+        memory: "2Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+
+raster:
+  settings:
+    resources:
+      requests:
+        cpu: "2"
+        memory: "4Gi"
+      limits:
+        cpu: "4"
+        memory: "8Gi"
+```
 
 ### Database Options
 

--- a/charts/eoapi/profiles/core.yaml
+++ b/charts/eoapi/profiles/core.yaml
@@ -31,13 +31,7 @@ postgrescluster:
         resources:
           requests:
             storage: "10Gi"
-      resources:
-        requests:
-          cpu: "1024m"
-          memory: "3048Mi"
-        limits:
-          cpu: "2048m"
-          memory: "4096Mi"
+      resources: {}
   users:
     - name: postgres
       databases:
@@ -71,13 +65,7 @@ pgstacBootstrap:
       context_estimated_cost: "100000"
       context_stats_ttl: "1 day"
 
-    resources:
-      requests:
-        cpu: "512m"
-        memory: "1024Mi"
-      limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+    resources: {}
 
 ######################
 # CORE API SERVICES
@@ -91,13 +79,7 @@ stac:
   autoscaling:
     enabled: false
   settings:
-    resources:
-      requests:
-        cpu: "512m"
-        memory: "1024Mi"
-      limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+    resources: {}
     envVars:
       HOST: "0.0.0.0"
       PORT: "8080"
@@ -114,13 +96,7 @@ raster:
   autoscaling:
     enabled: false
   settings:
-    resources:
-      requests:
-        cpu: "512m"
-        memory: "2048Mi"
-      limits:
-        cpu: "1024m"
-        memory: "4096Mi"
+    resources: {}
     envVars:
       # GDAL performance settings
       GDAL_CACHEMAX: "200"
@@ -148,13 +124,7 @@ vector:
   autoscaling:
     enabled: false
   settings:
-    resources:
-      requests:
-        cpu: "256m"
-        memory: "512Mi"
-      limits:
-        cpu: "512m"
-        memory: "1024Mi"
+    resources: {}
     envVars:
       TIPG_CATALOG_TTL: "300"
       TIPG_DEBUG: "False"

--- a/charts/eoapi/profiles/experimental.yaml
+++ b/charts/eoapi/profiles/experimental.yaml
@@ -42,13 +42,7 @@ postgrescluster:
         resources:
           requests:
             storage: "5Gi"
-      resources:
-        requests:
-          cpu: "512m"
-          memory: "1024Mi"
-        limits:
-          cpu: "1024m"
-          memory: "2048Mi"
+      resources: {}
   users:
     - name: postgres
       databases:
@@ -88,13 +82,7 @@ pgstacBootstrap:
       context_estimated_cost: "100000"
       context_stats_ttl: "1 day"
 
-    resources:
-      requests:
-        cpu: "256m"
-        memory: "1024Mi"
-      limits:
-        cpu: "512m"
-        memory: "1024Mi"
+    resources: {}
 
     envVars:
       LOAD_FIXTURES: "true"
@@ -109,15 +97,16 @@ stac:
     enabled: true
     path: "/stac"
   autoscaling:
-    enabled: false
+    enabled: true
+    type: "cpu"
+    minReplicas: 1
+    maxReplicas: 3
+    targets:
+      cpu: 75
   settings:
     resources:
       requests:
-        cpu: "512m"
-        memory: "1024Mi"
-      limits:
-        cpu: "1280m"
-        memory: "1536Mi"
+        cpu: "50m"
     envVars:
       HOST: "0.0.0.0"
       PORT: "8080"
@@ -132,15 +121,16 @@ raster:
     enabled: true
     path: "/raster"
   autoscaling:
-    enabled: false
+    enabled: true
+    type: "cpu"
+    minReplicas: 1
+    maxReplicas: 3
+    targets:
+      cpu: 75
   settings:
     resources:
       requests:
-        cpu: "256m"
-        memory: "1024Mi"
-      limits:
-        cpu: "768m"
-        memory: "4096Mi"
+        cpu: "50m"
     envVars:
       # GDAL performance settings
       GDAL_CACHEMAX: "200"
@@ -166,15 +156,16 @@ vector:
     enabled: true
     path: "/vector"
   autoscaling:
-    enabled: false
+    enabled: true
+    type: "cpu"
+    minReplicas: 1
+    maxReplicas: 3
+    targets:
+      cpu: 75
   settings:
     resources:
       requests:
-        cpu: "256m"
-        memory: "1024Mi"
-      limits:
-        cpu: "768m"
-        memory: "1536Mi"
+        cpu: "50m"
     envVars:
       TIPG_CATALOG_TTL: "300"
       TIPG_DEBUG: "True"
@@ -189,15 +180,16 @@ multidim:
     enabled: true
     path: "/multidim"
   autoscaling:
-    enabled: false
+    enabled: true
+    type: "cpu"
+    minReplicas: 1
+    maxReplicas: 3
+    targets:
+      cpu: 75
   settings:
     resources:
       requests:
-        cpu: "256m"
-        memory: "1024Mi"
-      limits:
-        cpu: "768m"
-        memory: "4096Mi"
+        cpu: "50m"
     envVars:
       GDAL_CACHEMAX: "200"
       GDAL_DISABLE_READDIR_ON_OPEN: "EMPTY_DIR"
@@ -218,13 +210,7 @@ multidim:
 browser:
   enabled: true
   settings:
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "64Mi"
-      limits:
-        cpu: "200m"
-        memory: "128Mi"
+    resources: {}
 
 docServer:
   enabled: true
@@ -260,13 +246,7 @@ eoapi-notifier:
               apiVersion: serving.knative.dev/v1
               kind: Service
               name: eoapi-cloudevents-sink
-  resources:
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-    limits:
-      cpu: "200m"
-      memory: "128Mi"
+  resources: {}
 
 ######################
 # KNATIVE
@@ -277,23 +257,11 @@ knative:
   initTimeout: "600s"
   cloudEventsSink:
     enabled: true
-    resources:
-      requests:
-        cpu: "50m"
-        memory: "64Mi"
-      limits:
-        cpu: "100m"
-        memory: "128Mi"
+    resources: {}
 
 knative-operator:
   tag: "v1.17.8"
-  resources:
-    requests:
-      cpu: "50m"
-      memory: "64Mi"
-    limits:
-      cpu: "200m"
-      memory: "256Mi"
+  resources: {}
 
 ######################
 # MONITORING
@@ -314,13 +282,7 @@ monitoring:
       enabled: true
     prometheus-node-exporter:
       enabled: true
-      resources:
-        limits:
-          cpu: "10m"
-          memory: "30Mi"
-        requests:
-          cpu: "10m"
-          memory: "30Mi"
+      resources: {}
     server:
       service:
         type: ClusterIP

--- a/charts/eoapi/values.schema.json
+++ b/charts/eoapi/values.schema.json
@@ -6,10 +6,6 @@
     "gitSha"
   ],
   "properties": {
-    "previousVersion": {
-      "type": "string",
-      "description": "Previous version when upgrading. Used for migrations (e.g., when upgrading from pre-0.7.0 versions)"
-    },
     "gitSha": {
       "type": "string",
       "description": "Git SHA of the deployment"

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -213,13 +213,7 @@ pgstacBootstrap:
     ### FOR CONFIGURING THE DB CONNECTION
     user: eoapi
     database: eoapi
-    resources:
-      requests:
-        cpu: "512m"
-        memory: "1024Mi"
-      limits:
-        cpu: "512m"
-        memory: "1024Mi"
+    resources: {}
     # DEPRECATED: Use pgstacBootstrap.settings.loadSamples instead
     envVars:
       # toggle to "false" if you don't want fixtures default loaded
@@ -269,21 +263,10 @@ raster:
     - "--host=$(HOST)"
     - "--port=$(PORT)"
   settings:
-    # Additional labels to add to the pod
     labels: {}
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "4096Mi"
-      requests:
-        cpu: "256m"
-        memory: "3072Mi"
-    # Additional environment variables from references like ConfigMap or Secret
+    resources: {}
     extraEnvFrom: []
-    # Additional volume mounts
     extraVolumeMounts: []
-    # Additional volumes
     extraVolumes: []
     envVars:
       ##############
@@ -342,21 +325,10 @@ multidim:
     - "--host=$(HOST)"
     - "--port=$(PORT)"
   settings:
-    # Additional labels to add to the pod
     labels: {}
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "4096Mi"
-      requests:
-        cpu: "256m"
-        memory: "3072Mi"
-    # Additional environment variables from references like ConfigMap or Secret
+    resources: {}
     extraEnvFrom: []
-    # Additional volume mounts
     extraVolumeMounts: []
-    # Additional volumes
     extraVolumes: []
     envVars:
       ##############
@@ -414,21 +386,10 @@ stac:
     - "--host=$(HOST)"
     - "--port=$(PORT)"
   settings:
-    # Additional labels to add to the pod
     labels: {}
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "1024Mi"
-      requests:
-        cpu: "256m"
-        memory: "1024Mi"
-    # Additional environment variables from references like ConfigMap or Secret
+    resources: {}
     extraEnvFrom: []
-    # Additional volume mounts
     extraVolumeMounts: []
-    # Additional volumes
     extraVolumes: []
     envVars:
       ##############
@@ -474,21 +435,10 @@ vector:
     - "--host=$(HOST)"
     - "--port=$(PORT)"
   settings:
-    # Additional labels to add to the pod
     labels: {}
-    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-    resources:
-      limits:
-        cpu: "768m"
-        memory: "1024Mi"
-      requests:
-        cpu: "256m"
-        memory: "256Mi"
-    # Additional environment variables from references like ConfigMap or Secret
+    resources: {}
     extraEnvFrom: []
-    # Additional volume mounts
     extraVolumeMounts: []
-    # Additional volumes
     extraVolumes: []
     envVars:
       ##############
@@ -510,7 +460,6 @@ vector:
 # It is a good idea to deploy stac-browser outside of k8s, since it's SPA with static files.
 browser:
   enabled: true
-  replicaCount: 1
   image:
     # we use a custom image with pathPrefix built into it
     name: ghcr.io/developmentseed/eoapi-k8s-stac-browser
@@ -576,24 +525,12 @@ knative:
   cloudEventsSink:
     enabled: false
     image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.6.4
-    resources:
-      requests:
-        cpu: 50m
-        memory: 64Mi
-      limits:
-        cpu: 100m
-        memory: 128Mi
+    resources: {}
 
 # Knative operator sub-chart configuration
 knative-operator:
   tag: "v1.17.8"
-  resources:
-    requests:
-      cpu: 50m
-      memory: 64Mi
-    limits:
-      cpu: 200m
-      memory: 256Mi
+  resources: {}
 
 ######################
 # MONITORING
@@ -617,13 +554,7 @@ monitoring:
       enabled: true
     prometheus-node-exporter:
       enabled: true
-      resources:
-        limits:
-          cpu: 10m
-          memory: 30Mi
-        requests:
-          cpu: 10m
-          memory: 30Mi
+      resources: {}
     server:
       service:
         type: ClusterIP  # Internal service, no external exposure by default
@@ -687,14 +618,7 @@ observability:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
         service.beta.kubernetes.io/aws-load-balancer-internal: "false"
-    # Resources consistent with eoapi.resources.grafana template in _resources.yaml
-    resources:
-      limits:
-        cpu: 100m
-        memory: 200Mi
-      requests:
-        cpu: 50m
-        memory: 100Mi
+    resources: {}
     datasources:
       datasources.yaml:
         apiVersion: 1
@@ -716,10 +640,3 @@ metrics-server:
     tag: "0.8.0-debian-12-r4"
   apiService:
     create: true
-
-# Version being upgraded from, used for migration purposes
-# Dont set the value in the values.yaml file
-# prefer to set it in the command line
-# helm upgrade --set previousVersion=$PREVIOUS_VERSION
-# or in the CI/CD pipeline
-previousVersion: ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,6 @@ Most fields have sensible defaults. Here are the core configuration options:
 |:--------------|:----------------|:------------|:------------|
 | `service.port` | Port for all services (vector/raster/stac) | 8080 | any valid port |
 | `gitSha` | SHA for deployment tracking | gitshaABC123 | any valid SHA |
-| `previousVersion` | Previous version during upgrades | "" | semantic version |
 
 ## Database Configuration
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -429,34 +429,12 @@ deploy_eoapi() {
         HELM_CMD="$HELM_CMD --set observability.grafana.enabled=true"
         HELM_CMD="$HELM_CMD --set monitoring.prometheusAdapter.prometheus.url=http://$RELEASE_NAME-prometheus-server.eoapi.svc.cluster.local"
 
-        # Enable autoscaling with CPU metrics
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.enabled=true"
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.type=cpu"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.enabled=true"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.type=cpu"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.enabled=true"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.type=cpu"
+
 
         # Enable notifier
         HELM_CMD="$HELM_CMD --set eoapi-notifier.enabled=true"
         # Fix eoapi-notifier secret name dynamically
         HELM_CMD="$HELM_CMD --set eoapi-notifier.config.sources[0].config.connection.existingSecret.name=$RELEASE_NAME-pguser-eoapi"
-        # Enable autoscaling for CI tests
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.enabled=true"
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.type=cpu"
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.targets.cpu=75"
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.minReplicas=1"
-        HELM_CMD="$HELM_CMD --set stac.autoscaling.maxReplicas=3"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.enabled=true"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.type=cpu"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.targets.cpu=75"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.minReplicas=1"
-        HELM_CMD="$HELM_CMD --set raster.autoscaling.maxReplicas=3"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.enabled=true"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.type=cpu"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.targets.cpu=75"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.minReplicas=1"
-        HELM_CMD="$HELM_CMD --set vector.autoscaling.maxReplicas=3"
     elif [ -f "./eoapi/test-local-values.yaml" ]; then
         log_info "Using local test configuration..."
         HELM_CMD="$HELM_CMD -f ./eoapi/test-local-values.yaml"


### PR DESCRIPTION
The current Helm chart contains several arbitrary default resource specifications and replica counts that add unnecessary complexity, create false assumptions about requirements, increase maintenance burden, and provide no real value since Kubernetes already has sensible defaults.

This PR proposes to just remove them.