### PR TITLE
fix: Add docker system prune for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
       - name: Set release name
         run: echo "RELEASE_NAME=eoapi-$(echo "${{ github.sha }}" | cut -c1-8)" >> "$GITHUB_ENV"
 
+      - name: Clean up disk space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          echo "=== Docker cleanup ==="
+          docker system prune -af --volumes || true
+          echo "=== Remove unused packages ==="
+          sudo apt-get clean || true
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          echo "=== Disk space after cleanup ==="
+          df -h
+
       - name: Start K3s cluster
         uses: jupyterhub/action-k3s-helm@v4
         with:
@@ -78,8 +90,11 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
+          echo "=== Cleaning up Helm release and namespace ==="
           helm uninstall "$RELEASE_NAME" -n eoapi || true
           kubectl delete namespace eoapi || true
+          echo "=== Cleaning up Docker resources ==="
+          docker system prune -af --volumes || true
 
   validate-docs:
     name: Validate documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Helm template to check queryables `file` field with schema validation [#380](https://github.com/developmentseed/eoapi-k8s/pull/380)
+- Cleaned up docker resources in CI workflow [#386](https://github.com/developmentseed/eoapi-k8s/pull/386)
 
 ## [0.8.1]
 


### PR DESCRIPTION
Stumbled over these errors with failing CI pipelines for several PRs:

```
Message: The node was low on resource: ephemeral-storage
Message: Pod was rejected: The node had condition: [DiskPressure]
Warning  FailedScheduling  0/1 nodes are available: 1 node(s) had untolerated taint(s)
```

This cleanup fixed a few things.