### PR TITLE
fix: app version corresponds to stac-fastapi-pgstac.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Validate Helm values schema
         run: ./eoapi-cli test schema
 
+      - name: Check app version consistency
+        run: |
+          CHART_VERSION=$(yq '.appVersion' charts/eoapi/Chart.yaml)
+          IMAGE_TAG=$(yq '.stac.image.tag' charts/eoapi/values.yaml)
+          if [ "$CHART_VERSION" != "$IMAGE_TAG" ]; then
+            echo "Version mismatch: Chart.yaml appVersion ($CHART_VERSION) != values.yaml stac.image.tag ($IMAGE_TAG)"
+            exit 1
+          fi
+
       - name: Run Helm unit tests
         uses: d3adb5/helm-unittest-action@v2
         with:

--- a/charts/eoapi/Chart.yaml
+++ b/charts/eoapi/Chart.yaml
@@ -26,7 +26,7 @@ annotations:
     - raster
     - vector
 version: 0.9.1
-appVersion: 6.1.5
+appVersion: 6.2.0
 dependencies:
   - name: postgrescluster
     version: 5.7.4

--- a/charts/eoapi/README.md
+++ b/charts/eoapi/README.md
@@ -1,7 +1,5 @@
 # eoAPI Helm Chart
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.1.0](https://img.shields.io/badge/AppVersion-6.1.0-informational?style=flat-square)
-
 A Helm chart for deploying Earth Observation APIs with integrated STAC, raster, vector, and multidimensional services.
 
 ## Features


### PR DESCRIPTION
The app version should match the version of `stac-fastapi-pgstac` but this has often times being missed.

* Adds a check to test for the versions to match,
* Removed badge in helm `README.md`, which is hard to maintain and gives little value,
* Adjusted the versions to match.