### PR TITLE
feat: add browser.extraEnv passthrough for stac-browser SB_* config

### DIFF
--- a/charts/eoapi/templates/services/browser/deployment.yaml
+++ b/charts/eoapi/templates/services/browser/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - name: SB_footerLinks
               value: {{ .Values.browser.footerLinks | toJson | trimPrefix "[" | trimSuffix "]" | quote }}
             {{- end }}
+            {{- with .Values.browser.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
           {{- toYaml .Values.browser.settings.resources | nindent 12 }}
 {{- end }}

--- a/charts/eoapi/tests/stac_browser_tests.yaml
+++ b/charts/eoapi/tests/stac_browser_tests.yaml
@@ -339,3 +339,44 @@ tests:
           content:
             name: SB_footerLinks
             value: '{"label":"Project Home","url":"https://example.com/"},{"label":"Documentation","url":"https://docs.example.com/"}'
+  - it: "stac browser deployment appends browser.extraEnv after the built-in env"
+    set:
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.extraEnv:
+        - name: SB_itemsPerPage
+          value: "60"
+      gitSha: "ABC123"
+    template: templates/services/browser/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      # the built-in env renders first; extraEnv is appended after it (additive, not a replacement)
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: SB_catalogUrl
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: SB_itemsPerPage
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "60"
+  - it: "stac browser deployment renders no extra env when browser.extraEnv is unset"
+    set:
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      gitSha: "ABC123"
+    template: templates/services/browser/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      # default extraEnv ([]) adds nothing — only the built-in SB_catalogUrl remains
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 1

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -625,6 +625,13 @@ browser:
   #     url: "https://example.com/terms"
   #   - label: "Privacy"
   #     url: "https://example.com/privacy"
+  # Extra environment variables for the browser container. Use this to set any stac-browser
+  # SB_<option> config not covered by the values above (https://github.com/radiantearth/stac-browser).
+  extraEnv: []
+  # Example:
+  # extraEnv:
+  #   - name: SB_itemsPerPage
+  #     value: "60"
   settings:
     labels: {}
     resources: {}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -324,6 +324,7 @@ raster:
 | `browser.catalogTitle` | Custom catalog title | "" | string |
 | `browser.catalogImage` | Custom catalog logo/image URL | "" | URL string |
 | `browser.footerLinks` | Custom footer links | `[]` | Array of `{label, url}` objects |
+| `browser.extraEnv` | Extra environment variables for the browser container, e.g. stac-browser `SB_*` config options not covered above (such as `SB_itemsPerPage`) | `[]` | Array of `{name, value}` objects |
 
 Example:
 


### PR DESCRIPTION
Fixes #524

## What

Adds a `browser.extraEnv` values list that is rendered onto the browser container's `env`, after the built-in `SB_*` vars:

```yaml
browser:
  extraEnv:
    - name: SB_itemsPerPage
      value: "60"
```

## Why

The browser Deployment hardcodes a fixed set of `SB_*` env vars (`SB_catalogUrl`, `SB_catalogTitle`, `SB_catalogImage`, `SB_authConfig`, `SB_footerLinks`) and exposes no way to set any **other** stac-browser config option from values. The stac-browser image already supports every option via `SB_<option>` env vars (its entrypoint types them from `config.schema.json`), so today setting e.g. `itemsPerPage` requires a brittle post-render patch on the rendered Deployment. This closes that gap with a generic passthrough — no per-option schema maintenance.

The implementation mirrors the existing `testing.mockOidcServer.extraEnv` pattern (`toYaml | nindent` into the container `env`), so it's additive and consistent with the chart.

## Changes

- `templates/services/browser/deployment.yaml` — render `browser.extraEnv` after the built-in env vars.
- `values.yaml` — add `browser.extraEnv: []` with an `SB_itemsPerPage` example.
- `tests/stac_browser_tests.yaml` — unit test asserting `extraEnv` is appended **and** the built-in `SB_catalogUrl` is preserved.
- `docs/configuration.md` — document `browser.extraEnv`.

## How tested

- `helm unittest charts/eoapi -f 'tests/stac_browser_tests.yaml'` → **14 passed** (13 existing + 1 new).
- `helm lint charts/eoapi` → passes.
- The browser `values.schema.json` already allows additional properties (existing `catalogUrl`/`catalogTitle` aren't enumerated either), so no schema change. CHANGELOG/version left to release-please.