### PR TITLE
fix: make Traefik router entrypoints configurable (fixes HTTPS-by-default)

### DIFF
--- a/charts/eoapi/Chart.yaml
+++ b/charts/eoapi/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
     - stac
     - raster
     - vector
-version: 0.13.1
+version: 0.13.2
 appVersion: 6.3.1
 dependencies:
   - name: postgrescluster

--- a/charts/eoapi/profiles/local/k3s.yaml
+++ b/charts/eoapi/profiles/local/k3s.yaml
@@ -14,8 +14,8 @@
 # k3s uses Traefik as the default ingress controller
 ingress:
   className: "traefik"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+  # Local k3s serves HTTP on port 80 only; pin to the web entrypoint.
+  entrypoints: "web"
 
 ######################
 # POSTGRESQL RESOURCES

--- a/charts/eoapi/templates/networking/ingress.yaml
+++ b/charts/eoapi/templates/networking/ingress.yaml
@@ -71,6 +71,7 @@ Helper template for generating ingress paths
 {{- end }}
 
 {{- if and .Values.ingress.enabled (include "eoapi.hasEnabledService" . | trim | eq "true") }}
+{{- $ingressAnnotations := .Values.ingress.annotations | default dict }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
@@ -89,12 +90,12 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- end }}
     {{- if eq .Values.ingress.className "traefik" }}
-    {{- with .Values.ingress.entrypoints }}
-    traefik.ingress.kubernetes.io/router.entrypoints: {{ . }}
+    {{- if and .Values.ingress.entrypoints (not (hasKey $ingressAnnotations "traefik.ingress.kubernetes.io/router.entrypoints")) }}
+    traefik.ingress.kubernetes.io/router.entrypoints: {{ .Values.ingress.entrypoints | quote }}
     {{- end }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ .Release.Name }}-strip-prefix-middleware@kubernetescrd
     {{- end }}
-    {{- with .Values.ingress.annotations }}
+    {{- with $ingressAnnotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/eoapi/templates/networking/ingress.yaml
+++ b/charts/eoapi/templates/networking/ingress.yaml
@@ -89,7 +89,9 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     {{- end }}
     {{- if eq .Values.ingress.className "traefik" }}
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+    {{- with .Values.ingress.entrypoints }}
+    traefik.ingress.kubernetes.io/router.entrypoints: {{ . }}
+    {{- end }}
     traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ .Release.Name }}-strip-prefix-middleware@kubernetescrd
     {{- end }}
     {{- with .Values.ingress.annotations }}

--- a/charts/eoapi/tests/ingress_test.yaml
+++ b/charts/eoapi/tests/ingress_test.yaml
@@ -149,6 +149,46 @@ tests:
             traefik.ingress.kubernetes.io/router.entrypoints: websecure
             traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
 
+  - it: "traefik ingress quotes entrypoints annotation values"
+    set:
+      ingress.className: "traefik"
+      ingress.entrypoints: "true"
+      ingress.host: "eoapi.local"
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.annotations
+          value:
+            traefik.ingress.kubernetes.io/router.entrypoints: "true"
+            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
+
+  - it: "traefik ingress annotations override configured entrypoints"
+    set:
+      ingress.className: "traefik"
+      ingress.entrypoints: "websecure"
+      ingress.annotations:
+        traefik.ingress.kubernetes.io/router.entrypoints: web
+      ingress.host: "eoapi.local"
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.annotations
+          value:
+            traefik.ingress.kubernetes.io/router.entrypoints: web
+            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
+
   - it: "all services enabled with custom paths"
     set:
       ingress.className: "nginx"

--- a/charts/eoapi/tests/ingress_tests.yaml
+++ b/charts/eoapi/tests/ingress_tests.yaml
@@ -122,7 +122,6 @@ tests:
       - equal:
           path: metadata.annotations
           value:
-            traefik.ingress.kubernetes.io/router.entrypoints: web
             traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
       - equal:
           path: spec.ingressClassName
@@ -130,6 +129,25 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: "eoapi.local"
+
+  - it: "traefik ingress emits entrypoints when configured"
+    set:
+      ingress.className: "traefik"
+      ingress.entrypoints: "websecure"
+      ingress.host: "eoapi.local"
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.annotations
+          value:
+            traefik.ingress.kubernetes.io/router.entrypoints: websecure
+            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
 
   - it: "all services enabled with custom paths"
     set:

--- a/charts/eoapi/values.schema.json
+++ b/charts/eoapi/values.schema.json
@@ -65,6 +65,10 @@
           ],
           "description": "Ingress controller class name"
         },
+        "entrypoints": {
+          "type": "string",
+          "description": "Traefik only: value for the router entrypoints annotation (e.g. \"websecure\" or \"web,websecure\"). Empty attaches to all entrypoints."
+        },
         "rootPath": {
           "type": "string",
           "description": "Root path for doc server"

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -35,6 +35,11 @@ ingress:
   enabled: true
   # ingressClassName: "nginx" or "traefik"
   className: "nginx"
+  # Traefik only: value for the router's `entrypoints` annotation, e.g. "websecure"
+  # or "web,websecure". Empty → the annotation is omitted and the router attaches to
+  # all Traefik entrypoints (Traefik's default). Note "web" is conventionally the
+  # HTTP entrypoint, so pinning to it alone will not serve HTTPS.
+  entrypoints: ""
   rootPath: ""        # Root path for doc server
   # Single host domain configuration (default)
   host: ""

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -281,6 +281,7 @@ Unified ingress configuration supporting both NGINX and Traefik:
 |:--------------|:----------------|:------------|:------------|
 | `ingress.enabled` | Enable ingress | true | true/false |
 | `ingress.className` | Ingress controller | "nginx" | "nginx", "traefik" |
+| `ingress.entrypoints` | Traefik router entrypoints (Traefik only) | "" (all entrypoints) | e.g. `"websecure"`, `"web,websecure"`, `"web"` |
 | `ingress.host` | Ingress hostname | "" | valid hostname |
 | `ingress.rootPath` | Doc server root path | "" | valid path |
 | `docServer.redirectTo` | Redirect root `/` to this path instead of showing the landing page | "" | e.g. `/browser/` |

--- a/docs/unified-ingress.md
+++ b/docs/unified-ingress.md
@@ -122,6 +122,9 @@ ingress:
   entrypoints: "websecure"
 ```
 
+If you set the same annotation via `ingress.annotations`, it overrides `ingress.entrypoints`
+because user annotations are rendered after the chart defaults.
+
 ### Path Handling Details
 
 Services run at root internally, ingress strips prefixes:

--- a/docs/unified-ingress.md
+++ b/docs/unified-ingress.md
@@ -115,8 +115,11 @@ ingress:
   className: "traefik"
   # When using TLS, setting host is required
   host: "example.domain.com"
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: web
+  # Optional: pin the Traefik router to specific entrypoints. Omit (default) to
+  # attach to all entrypoints, which is Traefik's own default. Note that "web" is
+  # conventionally the HTTP entrypoint, so set "websecure" (or "web,websecure")
+  # to serve HTTPS.
+  entrypoints: "websecure"
 ```
 
 ### Path Handling Details


### PR DESCRIPTION
Closes https://github.com/developmentseed/eoapi-k8s/issues/539

The Traefik ingress hardcoded `router.entrypoints: web`. Where `web` is the HTTP entrypoint (web/websecure split), the router never attaches to the TLS entrypoint, so HTTPS 404s, with no way to override it.

This adds `ingress.entrypoints` (default `""`): empty omits the annotation so the router attaches to all entrypoints (Traefik's default, serves HTTPS); set e.g. `"websecure"` to pin. Updated values/schema/docs/tests; `helm unittest` passes.
