### PR TITLE
fix(helm): redirect bare /browser to /browser/ on traefik

### DIFF
--- a/charts/eoapi/templates/networking/ingress.yaml
+++ b/charts/eoapi/templates/networking/ingress.yaml
@@ -93,8 +93,15 @@ metadata:
     {{- if and .Values.ingress.entrypoints (not (hasKey $ingressAnnotations "traefik.ingress.kubernetes.io/router.entrypoints")) }}
     traefik.ingress.kubernetes.io/router.entrypoints: {{ .Values.ingress.entrypoints | quote }}
     {{- end }}
-    {{- $browserRedirect := and .Values.browser .Values.browser.enabled (or (not .Values.browser.ingress) .Values.browser.ingress.enabled) }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ .Release.Name }}-strip-prefix-middleware@kubernetescrd{{ if $browserRedirect }},{{ .Release.Namespace }}-{{ .Release.Name }}-browser-redirect-middleware@kubernetescrd{{ end }}
+    {{- /* strip-prefix always; also chain the browser bare-path redirect when the browser ingress is on.
+           Keep this condition in sync with the redirect Middleware in traefik-middleware.yaml. */}}
+    {{- $mwPrefix := printf "%s-%s" .Release.Namespace .Release.Name }}
+    {{- $middlewares := list (printf "%s-strip-prefix-middleware@kubernetescrd" $mwPrefix) }}
+    {{- $browser := .Values.browser }}
+    {{- if and $browser $browser.enabled (or (not $browser.ingress) $browser.ingress.enabled) }}
+    {{- $middlewares = append $middlewares (printf "%s-browser-redirect-middleware@kubernetescrd" $mwPrefix) }}
+    {{- end }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $middlewares }}
     {{- end }}
     {{- with $ingressAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/eoapi/templates/networking/ingress.yaml
+++ b/charts/eoapi/templates/networking/ingress.yaml
@@ -93,7 +93,8 @@ metadata:
     {{- if and .Values.ingress.entrypoints (not (hasKey $ingressAnnotations "traefik.ingress.kubernetes.io/router.entrypoints")) }}
     traefik.ingress.kubernetes.io/router.entrypoints: {{ .Values.ingress.entrypoints | quote }}
     {{- end }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ .Release.Name }}-strip-prefix-middleware@kubernetescrd
+    {{- $browserRedirect := and .Values.browser .Values.browser.enabled (or (not .Values.browser.ingress) .Values.browser.ingress.enabled) }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-{{ .Release.Name }}-strip-prefix-middleware@kubernetescrd{{ if $browserRedirect }},{{ .Release.Namespace }}-{{ .Release.Name }}-browser-redirect-middleware@kubernetescrd{{ end }}
     {{- end }}
     {{- with $ingressAnnotations }}
     {{- toYaml . | nindent 4 }}

--- a/charts/eoapi/templates/networking/traefik-middleware.yaml
+++ b/charts/eoapi/templates/networking/traefik-middleware.yaml
@@ -37,4 +37,27 @@ spec:
       - {{ . }}
       {{- end }}
 {{- end }}
+
+{{/*
+Browser served under a sub-path (pathPrefix baked into the image) only answers on the
+trailing-slash form, so the bare path 404s and the prefix is intentionally not stripped.
+Traefik has no built-in append-slash, so redirect the exact bare path to its slash form.
+*/}}
+{{- $browser := .Values.browser }}
+{{- if and $browser $browser.enabled (or (not $browser.ingress) $browser.ingress.enabled) }}
+{{- $browserPath := trimSuffix "/" ($browser.ingress.path | default "/browser") }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ .Release.Name }}-browser-redirect-middleware
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-ingress
+spec:
+  redirectRegex:
+    regex: "^(https?://[^/]+){{ $browserPath }}$"
+    replacement: "${1}{{ $browserPath }}/"
+    permanent: true
+{{- end }}
 {{- end }}

--- a/charts/eoapi/templates/networking/traefik-middleware.yaml
+++ b/charts/eoapi/templates/networking/traefik-middleware.yaml
@@ -38,11 +38,9 @@ spec:
       {{- end }}
 {{- end }}
 
-{{/*
-Browser served under a sub-path (pathPrefix baked into the image) only answers on the
-trailing-slash form, so the bare path 404s and the prefix is intentionally not stripped.
-Traefik has no built-in append-slash, so redirect the exact bare path to its slash form.
-*/}}
+{{- /* Bare browser path 404s (pathPrefix is baked into the image) and Traefik has no
+       append-slash, so redirect the exact bare path to its trailing-slash form.
+       Keep this condition in sync with the router annotation in ingress.yaml. */}}
 {{- $browser := .Values.browser }}
 {{- if and $browser $browser.enabled (or (not $browser.ingress) $browser.ingress.enabled) }}
 {{- $browserPath := trimSuffix "/" ($browser.ingress.path | default "/browser") }}

--- a/charts/eoapi/tests/browser_redirect_test.yaml
+++ b/charts/eoapi/tests/browser_redirect_test.yaml
@@ -2,23 +2,22 @@ suite: browser bare-path redirect middleware
 templates:
   - templates/networking/traefik-middleware.yaml
   - templates/networking/ingress.yaml
+set:
+  ingress.enabled: true
+  ingress.className: traefik
+  ingress.host: eoapi.local
+  stac.enabled: false
+  raster.enabled: false
+  vector.enabled: false
+  multidim.enabled: false
 tests:
-  - it: "creates a redirectRegex middleware for the browser bare path on traefik"
+  - it: "redirects the browser bare path to its trailing-slash form on traefik"
     template: templates/networking/traefik-middleware.yaml
     set:
-      ingress.enabled: true
-      ingress.className: traefik
-      ingress.host: eoapi.local
-      stac.enabled: false
-      raster.enabled: false
-      vector.enabled: false
-      multidim.enabled: false
       browser.enabled: true
     asserts:
       - hasDocuments:
           count: 1
-      - isKind:
-          of: Middleware
       - equal:
           path: metadata.name
           value: RELEASE-NAME-browser-redirect-middleware
@@ -35,13 +34,6 @@ tests:
   - it: "honours a custom browser ingress path"
     template: templates/networking/traefik-middleware.yaml
     set:
-      ingress.enabled: true
-      ingress.className: traefik
-      ingress.host: eoapi.local
-      stac.enabled: false
-      raster.enabled: false
-      vector.enabled: false
-      multidim.enabled: false
       browser.enabled: true
       browser.ingress.path: "/stac-browser"
     asserts:
@@ -55,44 +47,16 @@ tests:
   - it: "still renders the redirect middleware for a root browser path so the router reference never dangles"
     template: templates/networking/traefik-middleware.yaml
     set:
-      ingress.enabled: true
-      ingress.className: traefik
-      ingress.host: eoapi.local
-      stac.enabled: false
-      raster.enabled: false
-      vector.enabled: false
-      multidim.enabled: false
       browser.enabled: true
       browser.ingress.path: "/"
     asserts:
       - hasDocuments:
           count: 1
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-browser-redirect-middleware
-
-  - it: "does not create the redirect middleware when the browser is disabled"
-    template: templates/networking/traefik-middleware.yaml
-    set:
-      ingress.enabled: true
-      ingress.className: traefik
-      ingress.host: eoapi.local
-      stac.enabled: true
-      browser.enabled: false
-    asserts:
-      - hasDocuments:
-          count: 1
-      - equal:
-          path: metadata.name
-          value: RELEASE-NAME-strip-prefix-middleware
 
   - it: "creates no traefik middleware on the nginx controller"
     template: templates/networking/traefik-middleware.yaml
     set:
-      ingress.enabled: true
       ingress.className: nginx
-      ingress.host: eoapi.local
-      stac.enabled: true
       browser.enabled: true
     asserts:
       - hasDocuments:
@@ -101,9 +65,6 @@ tests:
   - it: "chains the browser redirect middleware onto the traefik router annotation"
     template: templates/networking/ingress.yaml
     set:
-      ingress.enabled: true
-      ingress.className: traefik
-      ingress.host: eoapi.local
       stac.enabled: true
       browser.enabled: true
     asserts:
@@ -111,12 +72,9 @@ tests:
           path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
           value: "NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd,NAMESPACE-RELEASE-NAME-browser-redirect-middleware@kubernetescrd"
 
-  - it: "does not chain the redirect when the browser is disabled"
+  - it: "omits the browser redirect from the annotation when the browser is disabled"
     template: templates/networking/ingress.yaml
     set:
-      ingress.enabled: true
-      ingress.className: traefik
-      ingress.host: eoapi.local
       stac.enabled: true
       browser.enabled: false
     asserts:

--- a/charts/eoapi/tests/browser_redirect_test.yaml
+++ b/charts/eoapi/tests/browser_redirect_test.yaml
@@ -1,0 +1,125 @@
+suite: browser bare-path redirect middleware
+templates:
+  - templates/networking/traefik-middleware.yaml
+  - templates/networking/ingress.yaml
+tests:
+  - it: "creates a redirectRegex middleware for the browser bare path on traefik"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.host: eoapi.local
+      stac.enabled: false
+      raster.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Middleware
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-browser-redirect-middleware
+      - equal:
+          path: spec.redirectRegex.regex
+          value: "^(https?://[^/]+)/browser$"
+      - equal:
+          path: spec.redirectRegex.replacement
+          value: "${1}/browser/"
+      - equal:
+          path: spec.redirectRegex.permanent
+          value: true
+
+  - it: "honours a custom browser ingress path"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.host: eoapi.local
+      stac.enabled: false
+      raster.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.ingress.path: "/stac-browser"
+    asserts:
+      - equal:
+          path: spec.redirectRegex.regex
+          value: "^(https?://[^/]+)/stac-browser$"
+      - equal:
+          path: spec.redirectRegex.replacement
+          value: "${1}/stac-browser/"
+
+  - it: "still renders the redirect middleware for a root browser path so the router reference never dangles"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.host: eoapi.local
+      stac.enabled: false
+      raster.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.ingress.path: "/"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-browser-redirect-middleware
+
+  - it: "does not create the redirect middleware when the browser is disabled"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.host: eoapi.local
+      stac.enabled: true
+      browser.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-strip-prefix-middleware
+
+  - it: "creates no traefik middleware on the nginx controller"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.host: eoapi.local
+      stac.enabled: true
+      browser.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "chains the browser redirect middleware onto the traefik router annotation"
+    template: templates/networking/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.host: eoapi.local
+      stac.enabled: true
+      browser.enabled: true
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: "NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd,NAMESPACE-RELEASE-NAME-browser-redirect-middleware@kubernetescrd"
+
+  - it: "does not chain the redirect when the browser is disabled"
+    template: templates/networking/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: traefik
+      ingress.host: eoapi.local
+      stac.enabled: true
+      browser.enabled: false
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: "NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd"

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -81,7 +81,7 @@ run_integration_tests() {
     fi
 
     log_info "Ensuring all pods are ready..."
-    for service in stac raster vector; do
+    for service in stac raster vector browser; do
         local deployment="${RELEASE_NAME}-${service}"
         kubectl wait --for=condition=available deployment/"${deployment}" -n "$NAMESPACE" --timeout=60s 2>/dev/null || \
             log_warn "Deployment ${deployment} may not be fully ready"
@@ -94,12 +94,14 @@ run_integration_tests() {
     export RASTER_ENDPOINT="${RASTER_ENDPOINT:-http://$actual_host/raster}"
     export VECTOR_ENDPOINT="${VECTOR_ENDPOINT:-http://$actual_host/vector}"
     export MOCK_OIDC_ENDPOINT="${MOCK_OIDC_ENDPOINT:-http://$actual_host/mock-oidc}"
+    export BROWSER_ENDPOINT="${BROWSER_ENDPOINT:-http://$actual_host/browser}"
 
     log_info "Test endpoints configured:"
     log_info "  STAC: $STAC_ENDPOINT"
     log_info "  Raster: $RASTER_ENDPOINT"
     log_info "  Vector: $VECTOR_ENDPOINT"
     log_info "  Mock OIDC: $MOCK_OIDC_ENDPOINT"
+    log_info "  Browser: $BROWSER_ENDPOINT"
 
     log_info "Running service warmup..."
     for endpoint in "$STAC_ENDPOINT" "$RASTER_ENDPOINT/healthz" "$VECTOR_ENDPOINT/healthz"; do

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ def mock_oidc_endpoint() -> str:
     return os.getenv("MOCK_OIDC_ENDPOINT", "http://localhost/mock-oidc")
 
 
+@pytest.fixture(scope="session")
+def browser_endpoint() -> str:
+    return os.getenv("BROWSER_ENDPOINT", "http://localhost/browser")
+
+
 def get_mock_token(mock_oidc_endpoint: Optional[str] = None) -> str:
     """Get valid JWT token from mock OIDC server."""
     if mock_oidc_endpoint is None:

--- a/tests/integration/test_browser.py
+++ b/tests/integration/test_browser.py
@@ -1,0 +1,36 @@
+"""Integration test for the STAC Browser bare-path redirect on Traefik.
+
+The browser image bakes in a ``pathPrefix``, so it only answers on the
+trailing-slash form and the bare path used to 404. The chart adds a Traefik
+``redirectRegex`` middleware so ``GET /browser`` 301-redirects to ``/browser/``.
+See PR #544 / issue #545.
+"""
+
+import os
+
+import httpx
+
+# Same client setup as the other integration modules, but keep redirects
+# unfollowed so we can assert on the 301 itself.
+timeout = httpx.Timeout(15.0, connect=60.0)
+if bool(os.getenv("IGNORE_SSL_VERIFICATION", False)):
+    client = httpx.Client(timeout=timeout, verify=False, follow_redirects=False)
+else:
+    client = httpx.Client(timeout=timeout, follow_redirects=False)
+
+
+def test_browser_bare_path_redirects_to_slash(browser_endpoint: str) -> None:
+    """GET /browser 301-redirects to /browser/ (Traefik redirect middleware).
+
+    The redirect is handled by Traefik, so it holds even before the browser
+    pod is ready.
+    """
+    resp = client.get(browser_endpoint)
+    assert resp.status_code == 301
+    assert resp.headers["location"] == f"{browser_endpoint}/"
+
+
+def test_browser_trailing_slash_serves(browser_endpoint: str) -> None:
+    """The trailing-slash form serves the STAC Browser app (HTTP 200)."""
+    resp = client.get(f"{browser_endpoint}/")
+    assert resp.status_code == 200


### PR DESCRIPTION
closes https://github.com/developmentseed/eoapi-k8s/issues/545

## Summary

After deploying eoAPI with Traefik in EOPF I noticed 404 on `/browser`.

After debugging it with Claude I identified the issue:  Chart defaults `browser.ingress.path: "/browser"`, but the stac-browser image is built with `pathPrefix=/browser/`. On traefik the prefix isn't stripped, so the bare path is returning 404:

```
GET /browser   -> 404
GET /browser/  -> 200
```


## For reviewers

- The regex in the Middleware is the part I'd most value a second look at:  it must match the bare path exactly without catching subpaths.
- I'm confident in the runtime behavior: the identical redirect runs in  production (api.explorer.eopf.copernicus.eu, chart 0.13.2), where  `GET /browser -> 301 -> /browser/ -> 200`.
- I added tests to catch this behavior: `browser_redirect_test.yaml`

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and under every change and can explain why each is correct.

AI coding assistance was used for the identifying the issue, create a fix and generate the tests; I have reviewed every change and verified the behavior on a live cluster that use Traefik.
