### PR TITLE
fix: align HPA request-rate metrics with prometheus-adapter rules

### DIFF
--- a/charts/eoapi/profiles/experimental.yaml
+++ b/charts/eoapi/profiles/experimental.yaml
@@ -266,54 +266,23 @@ monitoring:
 
   prometheus:
     enabled: true
-    alertmanager:
-      enabled: false
-    prometheus-pushgateway:
-      enabled: false
-    kube-state-metrics:
-      enabled: true
-    prometheus-node-exporter:
-      enabled: true
-      resources: {}
-    server:
-      service:
-        type: ClusterIP
 
   prometheusAdapter:
     enabled: true
-    prometheus:
-      url: http://eoapi-prometheus-server.eoapi.svc.cluster.local
-      port: 80
-      path: ""
-    rules:
-      default: false
-      custom:
-        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
-          seriesFilters: []
-          resources:
-            template: <<.Resource>>
-          name:
-            matches: ""
-            as: "nginx_ingress_controller_requests_rate_vector_eoapi"
-          metricsQuery: round(sum(rate(<<.Series>>{service="vector",path=~"/vector.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
 
-        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
-          seriesFilters: []
-          resources:
-            template: <<.Resource>>
-          name:
-            matches: ""
-            as: "nginx_ingress_controller_requests_rate_raster_eoapi"
-          metricsQuery: round(sum(rate(<<.Series>>{service="raster",path=~"/raster.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
-
-        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
-          seriesFilters: []
-          resources:
-            template: <<.Resource>>
-          name:
-            matches: ""
-            as: "nginx_ingress_controller_requests_rate_stac_eoapi"
-          metricsQuery: round(sum(rate(<<.Series>>{service="stac",path=~"/stac.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
+prometheus:
+  alertmanager:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+  kube-state-metrics:
+    enabled: true
+  prometheus-node-exporter:
+    enabled: true
+    resources: {}
+  server:
+    service:
+      type: ClusterIP
 
 ######################
 # OBSERVABILITY

--- a/charts/eoapi/profiles/production.yaml
+++ b/charts/eoapi/profiles/production.yaml
@@ -88,39 +88,43 @@ monitoring:
 
   prometheus:
     enabled: true
-    alertmanager:
-      enabled: false  # Use Grafana alerting instead
-    prometheus-pushgateway:
-      enabled: false
-    kube-state-metrics:
-      enabled: true
-    prometheus-node-exporter:
-      enabled: true
-      resources:
-        limits:
-          cpu: "50m"
-          memory: "64Mi"
-        requests:
-          cpu: "50m"
-          memory: "64Mi"
-    server:
-      persistentVolume:
-        enabled: true
-        size: 30Gi
-      retention: "15d"
-      resources:
-        limits:
-          cpu: "1000m"
-          memory: "2048Mi"
-        requests:
-          cpu: "500m"
-          memory: "1024Mi"
-      service:
-        type: ClusterIP
 
-# Custom metrics for request-rate based autoscaling
-prometheusAdapter:
-  enabled: true
+  prometheusAdapter:
+    enabled: true
+
+prometheus:
+  alertmanager:
+    enabled: false  # Use Grafana alerting instead
+  prometheus-pushgateway:
+    enabled: false
+  kube-state-metrics:
+    enabled: true
+  prometheus-node-exporter:
+    enabled: true
+    resources:
+      limits:
+        cpu: "50m"
+        memory: "64Mi"
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+  server:
+    persistentVolume:
+      enabled: true
+      size: 30Gi
+    retention: "15d"
+    resources:
+      limits:
+        cpu: "1000m"
+        memory: "2048Mi"
+      requests:
+        cpu: "500m"
+        memory: "1024Mi"
+    service:
+      type: ClusterIP
+
+# Request-rate adapter rules: inherited from values.yaml prometheus-adapter.rules.custom
+prometheus-adapter:
   resources:
     limits:
       cpu: "200m"
@@ -362,13 +366,3 @@ serviceAccount:
 ######################
 service:
   port: 8080
-
-# Enable autoscaling globally
-autoscaling:
-  enabled: true
-
-# Connection pooling for better performance
-database:
-  enabled: true
-  connectionPooling:
-    enabled: true

--- a/charts/eoapi/templates/_helpers/services.tpl
+++ b/charts/eoapi/templates/_helpers/services.tpl
@@ -28,6 +28,15 @@ Helper function for common environment variables
 {{- end -}}
 
 {{/*
+Return prometheus-adapter custom metric name for request-rate HPA per service.
+Canonical source for name.as in prometheus-adapter.rules.custom (values.yaml).
+Validated at render time by eoapi.validateHpaAdapterMetricAlignment.
+*/}}
+{{- define "eoapi.hpaRequestRateMetricName" -}}
+{{- printf "nginx_ingress_controller_requests_rate_%s_eoapi" .service -}}
+{{- end -}}
+
+{{/*
 Helper function for common init containers to wait for pgstac jobs
 */}}
 {{- define "eoapi.pgstacInitContainers" -}}

--- a/charts/eoapi/templates/_helpers/validation.tpl
+++ b/charts/eoapi/templates/_helpers/validation.tpl
@@ -28,6 +28,35 @@ so we use this helper function to check autoscaling rules
 {{- end -}}
 
 {{/*
+Ensure prometheus-adapter custom metric names match HPA request-rate metrics.
+*/}}
+{{- define "eoapi.validateHpaAdapterMetricAlignment" -}}
+{{- if .Values.monitoring.prometheusAdapter.enabled }}
+{{- $adapter := index .Values "prometheus-adapter" | default dict }}
+{{- $rules := list }}
+{{- if and $adapter.rules $adapter.rules.custom }}
+{{- $rules = $adapter.rules.custom }}
+{{- end }}
+{{- range .Values.apiServices }}
+{{- $service := . }}
+{{- $autoscaling := index $.Values $service "autoscaling" | default dict }}
+{{- if and $autoscaling.enabled (or (eq $autoscaling.type "requestRate") (eq $autoscaling.type "both")) }}
+{{- $expected := include "eoapi.hpaRequestRateMetricName" (dict "service" $service) | trim }}
+{{- $found := false }}
+{{- range $rules }}
+{{- if and .name .name.as (eq .name.as $expected) }}
+{{- $found = true }}
+{{- end }}
+{{- end }}
+{{- if not $found }}
+{{- fail (printf "prometheus-adapter.rules.custom must define name.as %q for request-rate HPA (service %q). See eoapi.hpaRequestRateMetricName in _helpers/services.tpl" $expected $service) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Validate stac-auth-proxy configuration
 Ensures OIDC_DISCOVERY_URL is set when stac-auth-proxy is enabled
 Ensures stac-auth-proxy cannot be enabled when stac is disabled

--- a/charts/eoapi/templates/core/validation.yaml
+++ b/charts/eoapi/templates/core/validation.yaml
@@ -4,3 +4,5 @@ It doesn't create any resources but ensures configuration consistency.
 */}}
 {{- include "eoapi.validatePostgresql" . }}
 {{- include "eoapi.validateStacAuthProxy" . }}
+{{- include "eoapi.validateAutoscaleRules" . }}
+{{- include "eoapi.validateHpaAdapterMetricAlignment" . }}

--- a/charts/eoapi/templates/services/multidim/hpa.yaml
+++ b/charts/eoapi/templates/services/multidim/hpa.yaml
@@ -31,7 +31,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "multidim") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.multidim.autoscaling.targets.requestRate }}
@@ -45,7 +45,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "multidim") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.multidim.autoscaling.targets.requestRate }}

--- a/charts/eoapi/templates/services/raster/hpa.yaml
+++ b/charts/eoapi/templates/services/raster/hpa.yaml
@@ -31,7 +31,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "raster") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.raster.autoscaling.targets.requestRate }}
@@ -45,7 +45,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "raster") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.raster.autoscaling.targets.requestRate }}

--- a/charts/eoapi/templates/services/stac/hpa.yaml
+++ b/charts/eoapi/templates/services/stac/hpa.yaml
@@ -31,7 +31,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "stac") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.stac.autoscaling.targets.requestRate }}
@@ -45,7 +45,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "stac") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.stac.autoscaling.targets.requestRate }}

--- a/charts/eoapi/templates/services/vector/hpa.yaml
+++ b/charts/eoapi/templates/services/vector/hpa.yaml
@@ -31,7 +31,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "vector") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.vector.autoscaling.targets.requestRate }}
@@ -45,7 +45,7 @@ spec:
     - type: Pods
       pods:
         metric:
-          name: nginx_ingress_controller_requests
+          name: {{ include "eoapi.hpaRequestRateMetricName" (dict "service" "vector") }}
         target:
           type: AverageValue
           averageValue: {{ .Values.vector.autoscaling.targets.requestRate }}

--- a/charts/eoapi/tests/autoscaling_test.yaml
+++ b/charts/eoapi/tests/autoscaling_test.yaml
@@ -1,5 +1,6 @@
 suite: autoscaling tests
 templates:
+  - templates/_helpers/services.tpl
   - templates/services/stac/hpa.yaml
   - templates/services/raster/hpa.yaml
   - templates/services/vector/hpa.yaml
@@ -72,7 +73,7 @@ tests:
           value: "Pods"
       - equal:
           path: spec.metrics[0].pods.metric.name
-          value: "nginx_ingress_controller_requests"
+          value: "nginx_ingress_controller_requests_rate_stac_eoapi"
       - equal:
           path: spec.metrics[0].pods.target.averageValue
           value: "50000m"
@@ -99,7 +100,7 @@ tests:
           value: "Pods"
       - equal:
           path: spec.metrics[1].pods.metric.name
-          value: "nginx_ingress_controller_requests"
+          value: "nginx_ingress_controller_requests_rate_stac_eoapi"
 
   - it: "raster hpa created with request rate autoscaling"
     set:
@@ -113,7 +114,7 @@ tests:
           of: HorizontalPodAutoscaler
       - equal:
           path: spec.metrics[0].pods.metric.name
-          value: "nginx_ingress_controller_requests"
+          value: "nginx_ingress_controller_requests_rate_raster_eoapi"
       - equal:
           path: spec.metrics[0].pods.target.averageValue
           value: "30000m"
@@ -130,7 +131,7 @@ tests:
           of: HorizontalPodAutoscaler
       - equal:
           path: spec.metrics[0].pods.metric.name
-          value: "nginx_ingress_controller_requests"
+          value: "nginx_ingress_controller_requests_rate_vector_eoapi"
       - equal:
           path: spec.metrics[0].pods.target.averageValue
           value: "40000m"
@@ -157,6 +158,23 @@ tests:
       - equal:
           path: spec.metrics[0].resource.target.averageUtilization
           value: 80
+
+  - it: "multidim hpa created with request rate autoscaling"
+    set:
+      multidim.enabled: true
+      multidim.autoscaling.enabled: true
+      multidim.autoscaling.type: "requestRate"
+      multidim.autoscaling.targets.requestRate: "100000m"
+    template: templates/services/multidim/hpa.yaml
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.metrics[0].pods.metric.name
+          value: "nginx_ingress_controller_requests_rate_multidim_eoapi"
+      - equal:
+          path: spec.metrics[0].pods.target.averageValue
+          value: "100000m"
 
   - it: "hpa scaleTargetRef points to correct deployment"
     set:

--- a/charts/eoapi/tests/profiles_production_test.yaml
+++ b/charts/eoapi/tests/profiles_production_test.yaml
@@ -1,0 +1,34 @@
+suite: production profile release tests
+templates:
+  - templates/_helpers/services.tpl
+  - templates/services/stac/hpa.yaml
+  - templates/services/raster/hpa.yaml
+tests:
+  - it: production profile enables stac HPA with adapter metric names
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: templates/services/stac/hpa.yaml
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.metrics[1].pods.metric.name
+          value: nginx_ingress_controller_requests_rate_stac_eoapi
+
+  - it: production profile enables raster HPA with adapter metric names
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: templates/services/raster/hpa.yaml
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.metrics[1].pods.metric.name
+          value: nginx_ingress_controller_requests_rate_raster_eoapi

--- a/charts/eoapi/tests/prometheus_adapter_test.yaml
+++ b/charts/eoapi/tests/prometheus_adapter_test.yaml
@@ -1,0 +1,63 @@
+suite: prometheus adapter subchart tests
+templates:
+  - charts/prometheus-adapter/templates/configmap.yaml
+  - charts/prometheus-adapter/templates/deployment.yaml
+tests:
+  - it: default values expose per-service request rate rules
+    set:
+      monitoring.prometheusAdapter.enabled: true
+      gitSha: ABC123
+    template: charts/prometheus-adapter/templates/configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_stac_eoapi
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_raster_eoapi
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_vector_eoapi
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_multidim_eoapi
+      - notMatchRegex:
+          path: data['config.yaml']
+          pattern: container_.*_seconds_total
+
+  - it: production profile points adapter at release prometheus
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: charts/prometheus-adapter/templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--prometheus-url=http://eoapi-prometheus-server.eoapi.svc.cluster.local:80"
+
+  - it: production profile inherits request rate rules aligned with HPA metric names
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: charts/prometheus-adapter/templates/configmap.yaml
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_stac_eoapi
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_raster_eoapi
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_vector_eoapi
+      - matchRegex:
+          path: data['config.yaml']
+          pattern: nginx_ingress_controller_requests_rate_multidim_eoapi

--- a/charts/eoapi/tests/prometheus_test.yaml
+++ b/charts/eoapi/tests/prometheus_test.yaml
@@ -1,0 +1,45 @@
+suite: prometheus subchart tests
+templates:
+  - charts/prometheus/templates/deploy.yaml
+  - charts/prometheus/templates/pvc.yaml
+tests:
+  - it: default values configure prometheus server service type
+    set:
+      monitoring.prometheus.enabled: true
+      gitSha: ABC123
+    template: charts/prometheus/templates/deploy.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--storage.tsdb.retention.time=15d"
+
+  - it: production profile applies retention and resource limits
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: charts/prometheus/templates/deploy.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: "--storage.tsdb.retention.time=15d"
+      - equal:
+          path: spec.template.spec.containers[1].resources.limits.memory
+          value: 2048Mi
+
+  - it: production profile enables prometheus persistent volume
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: charts/prometheus/templates/pvc.yaml
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: spec.resources.requests.storage
+          value: 30Gi

--- a/charts/eoapi/tests/validation_test.yaml
+++ b/charts/eoapi/tests/validation_test.yaml
@@ -1,0 +1,80 @@
+suite: validation tests
+templates:
+  - templates/core/validation.yaml
+  - templates/_helpers/services.tpl
+  - templates/_helpers/validation.tpl
+  - templates/_helpers/database.tpl
+tests:
+  - it: passes when prometheus adapter is enabled but no request-rate autoscaling is active
+    set:
+      monitoring.prometheusAdapter.enabled: true
+      gitSha: ABC123
+    template: templates/core/validation.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: passes when request-rate autoscaling is enabled and adapter rules match
+    set:
+      monitoring.prometheusAdapter.enabled: true
+      gitSha: ABC123
+      stac.autoscaling.enabled: true
+      stac.autoscaling.type: requestRate
+    template: templates/core/validation.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: passes when prometheus adapter is enabled and all autoscaling is cpu-only
+    set:
+      monitoring.prometheusAdapter.enabled: true
+      gitSha: ABC123
+      stac.autoscaling.enabled: true
+      stac.autoscaling.type: cpu
+      raster.autoscaling.enabled: true
+      raster.autoscaling.type: cpu
+      prometheus-adapter.rules.custom: []
+    template: templates/core/validation.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when adapter rules omit a request-rate service metric name
+    set:
+      monitoring.prometheusAdapter.enabled: true
+      gitSha: ABC123
+      raster.autoscaling.enabled: true
+      raster.autoscaling.type: requestRate
+      prometheus-adapter.rules.custom:
+        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
+          seriesFilters: []
+          resources:
+            template: <<.Resource>>
+          name:
+            matches: ""
+            as: "nginx_ingress_controller_requests_rate_vector_eoapi"
+          metricsQuery: round(sum(rate(<<.Series>>{service="vector",path=~"/vector.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
+    template: templates/core/validation.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: prometheus-adapter.rules.custom must define name.as "nginx_ingress_controller_requests_rate_raster_eoapi" for request-rate HPA (service "raster"). See eoapi.hpaRequestRateMetricName in _helpers/services.tpl
+
+  - it: passes production profile with request-rate autoscaling and default adapter rules
+    values:
+      - ../profiles/production.yaml
+    set:
+      gitSha: ABC123
+    template: templates/core/validation.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: skips adapter metric alignment when prometheus adapter is disabled
+    set:
+      monitoring.prometheusAdapter.enabled: false
+      prometheus-adapter.rules.custom: []
+      gitSha: ABC123
+    template: templates/core/validation.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/eoapi/values.schema.json
+++ b/charts/eoapi/values.schema.json
@@ -795,6 +795,80 @@
           }
         }
       }
+    },
+    "prometheus": {
+      "type": "object",
+      "description": "Values passed to the prometheus Helm sub-chart",
+      "properties": {
+        "alertmanager": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "kube-state-metrics": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "prometheus-node-exporter": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "prometheus-pushgateway": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "server": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "prometheus-adapter": {
+      "type": "object",
+      "description": "Values passed to the prometheus-adapter Helm sub-chart",
+      "properties": {
+        "prometheus": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "Prometheus server URL for custom metrics queries"
+            },
+            "port": {
+              "type": "integer",
+              "description": "Prometheus server port"
+            },
+            "path": {
+              "type": "string",
+              "description": "Prometheus server path prefix"
+            }
+          },
+          "additionalProperties": true
+        },
+        "rules": {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "boolean",
+              "description": "Enable default prometheus-adapter resource rules"
+            },
+            "custom": {
+              "type": "array",
+              "description": "Custom metrics rules. name.as must match eoapi.hpaRequestRateMetricName per apiServices entry.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resource requests and limits for prometheus-adapter"
+        }
+      },
+      "additionalProperties": true
     }
   },
   "definitions": {

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -746,66 +746,13 @@ monitoring:
     apiService:
       create: true
 
-  # Prometheus - core metrics collection for autoscaling
+  # Prometheus - core metrics collection for autoscaling (subchart config: prometheus)
   prometheus:
     enabled: false
-    alertmanager:
-      enabled: false
-    prometheus-pushgateway:
-      enabled: false
-    kube-state-metrics:
-      enabled: true
-    prometheus-node-exporter:
-      enabled: true
-      resources: {}
-    server:
-      service:
-        type: ClusterIP  # Internal service, no external exposure by default
 
-  # Prometheus adapter - enables custom HPA metrics
+  # Prometheus adapter - enables custom HPA metrics (subchart config: prometheus-adapter)
   prometheusAdapter:
     enabled: false
-    prometheus:
-      # URL to Prometheus server - will be auto-configured for same-release Prometheus
-      # If using external Prometheus, set this to your Prometheus URL
-      # Example: http://my-prometheus-server.monitoring.svc.cluster.local
-      url: http://eoapi-prometheus-server.eoapi.svc.cluster.local
-      port: 80
-      path: ""
-    rules:
-      default: false
-      # Custom metrics for eoapi service autoscaling
-      # Each service gets its own request rate metric for HPA scaling
-      custom:
-        # Vector service request rate metric
-        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
-          seriesFilters: []
-          resources:
-            template: <<.Resource>>
-          name:
-            matches: ""
-            as: "nginx_ingress_controller_requests_rate_vector_eoapi"
-          metricsQuery: round(sum(rate(<<.Series>>{service="vector",path=~"/vector.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
-
-        # Raster service request rate metric
-        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
-          seriesFilters: []
-          resources:
-            template: <<.Resource>>
-          name:
-            matches: ""
-            as: "nginx_ingress_controller_requests_rate_raster_eoapi"
-          metricsQuery: round(sum(rate(<<.Series>>{service="raster",path=~"/raster.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
-
-        # STAC service request rate metric
-        - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
-          seriesFilters: []
-          resources:
-            template: <<.Resource>>
-          name:
-            matches: ""
-            as: "nginx_ingress_controller_requests_rate_stac_eoapi"
-          metricsQuery: round(sum(rate(<<.Series>>{service="stac",path=~"/stac.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
 
 ######################
 # OBSERVABILITY
@@ -839,3 +786,75 @@ observability:
 metrics-server:
   apiService:
     create: true
+
+# Prometheus sub-chart configuration
+# These values are passed directly to the prometheus sub-chart
+prometheus:
+  alertmanager:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+  kube-state-metrics:
+    enabled: true
+  prometheus-node-exporter:
+    enabled: true
+    resources: {}
+  server:
+    service:
+      type: ClusterIP  # Internal service, no external exposure by default
+
+# Prometheus Adapter sub-chart configuration
+# These values are passed directly to the prometheus-adapter sub-chart.
+# rules.custom[].name.as must match eoapi.hpaRequestRateMetricName per apiServices entry.
+prometheus-adapter:
+  prometheus:
+    # URL to Prometheus server - will be auto-configured for same-release Prometheus
+    # If using external Prometheus, set this to your Prometheus URL
+    # Example: http://my-prometheus-server.monitoring.svc.cluster.local
+    url: http://eoapi-prometheus-server.eoapi.svc.cluster.local
+    port: 80
+    path: ""
+  rules:
+    default: false
+    # Custom metrics for eoapi service autoscaling
+    # Each service gets its own request rate metric for HPA scaling
+    custom:
+      # Vector service request rate metric
+      - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
+        seriesFilters: []
+        resources:
+          template: <<.Resource>>
+        name:
+          matches: ""
+          as: "nginx_ingress_controller_requests_rate_vector_eoapi"
+        metricsQuery: round(sum(rate(<<.Series>>{service="vector",path=~"/vector.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
+
+      # Raster service request rate metric
+      - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
+        seriesFilters: []
+        resources:
+          template: <<.Resource>>
+        name:
+          matches: ""
+          as: "nginx_ingress_controller_requests_rate_raster_eoapi"
+        metricsQuery: round(sum(rate(<<.Series>>{service="raster",path=~"/raster.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
+
+      # STAC service request rate metric
+      - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
+        seriesFilters: []
+        resources:
+          template: <<.Resource>>
+        name:
+          matches: ""
+          as: "nginx_ingress_controller_requests_rate_stac_eoapi"
+        metricsQuery: round(sum(rate(<<.Series>>{service="stac",path=~"/stac.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)
+
+      # Multidim service request rate metric
+      - seriesQuery: '{__name__=~"^nginx_ingress_controller_requests$",namespace!=""}'
+        seriesFilters: []
+        resources:
+          template: <<.Resource>>
+        name:
+          matches: ""
+          as: "nginx_ingress_controller_requests_rate_multidim_eoapi"
+        metricsQuery: round(sum(rate(<<.Series>>{service="multidim",path=~"/multidim.*",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>), 0.001)

--- a/charts/eoapi/values/monitoring.yaml
+++ b/charts/eoapi/values/monitoring.yaml
@@ -20,35 +20,36 @@ monitoring:
         cpu: 10m
         memory: 30Mi
 
-  # Prometheus stack
   prometheus:
     enabled: true
-    alertmanager:
+
+prometheus:
+  alertmanager:
+    enabled: false
+  prometheus-pushgateway:
+    enabled: false
+
+  kube-state-metrics:
+    enabled: true
+    resources: *small_resources
+
+  prometheus-node-exporter:
+    enabled: true
+    resources: *small_resources
+
+  server:
+    service:
+      type: ClusterIP
+    persistentVolume:
       enabled: false
-    prometheus-pushgateway:
-      enabled: false
-
-    kube-state-metrics:
-      enabled: true
-      resources: *small_resources
-
-    prometheus-node-exporter:
-      enabled: true
-      resources: *small_resources
-
-    server:
-      service:
-        type: ClusterIP
-      persistentVolume:
-        enabled: false
-        size: 8Gi
-      resources:
-        limits:
-          cpu: 500m
-          memory: 512Mi
-        requests:
-          cpu: 200m
-          memory: 256Mi
+      size: 8Gi
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 200m
+        memory: 256Mi
 
 # Autoscaling defaults
 autoscaling:

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -284,24 +284,30 @@ targets:
 
 ## Custom Metrics Configuration
 
-When using request rate scaling, the prometheus-adapter needs to be configured to expose custom metrics. This is handled automatically when you enable monitoring in the main chart:
+When using request rate scaling, the prometheus-adapter needs to be configured to expose custom metrics. Enable the adapter under `monitoring.prometheusAdapter`; configure the subchart under top-level `prometheus-adapter`:
 
 ```yaml
 # In your main eoapi values file
 ingress:
   host: your-domain.com
 
+# Install prometheus-adapter (Helm dependency condition)
 monitoring:
   prometheusAdapter:
     enabled: true
-    resources:
-      limits:
-        cpu: 250m
-        memory: 256Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
+
+# Values passed to the prometheus-adapter subchart
+prometheus-adapter:
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 ```
+
+Per-service request-rate metric names are derived from `eoapi.hpaRequestRateMetricName` and must match `prometheus-adapter.rules.custom[].name.as` (for example `nginx_ingress_controller_requests_rate_stac_eoapi`).
 
 ## Service-Specific Examples
 
@@ -403,8 +409,9 @@ kubectl describe hpa eoapi-stac -n eoapi
 # Check if custom metrics API is available
 kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1" | jq .
 
-# Check specific request rate metrics
-kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/eoapi/ingresses/*/requests_per_second" | jq .
+# Check per-service request rate metrics exposed by prometheus-adapter
+# Replace <namespace> and metric suffix (stac, raster, vector, multidim) as needed
+kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/<namespace>/pods/*/nginx_ingress_controller_requests_rate_stac_eoapi" | jq .
 ```
 
 ### Check Prometheus Adapter

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -73,15 +73,17 @@ monitoring:
     enabled: true
   prometheus:
     enabled: true
-    server:
-      persistentVolume:
-        enabled: true
-        size: 50Gi
-      retention: "30d"
-    kube-state-metrics:
+
+prometheus:
+  server:
+    persistentVolume:
       enabled: true
-    prometheus-node-exporter:
-      enabled: true
+      size: 50Gi
+    retention: "30d"
+  kube-state-metrics:
+    enabled: true
+  prometheus-node-exporter:
+    enabled: true
 ```
 
 #### Observability Chart Configuration
@@ -170,25 +172,28 @@ The `eoapi-observability` chart provides ready-to-use dashboards:
 ```yaml
 monitoring:
   prometheus:
-    server:
-      # Persistent storage
-      persistentVolume:
-        enabled: true
-        size: 100Gi
-        storageClass: "gp3"
-      # Retention policy
-      retention: "30d"
-      # Resource allocation
-      resources:
-        limits:
-          cpu: "2000m"
-          memory: "4096Mi"
-        requests:
-          cpu: "1000m"
-          memory: "2048Mi"
-      # Security - internal access only
-      service:
-        type: ClusterIP
+    enabled: true
+
+prometheus:
+  server:
+    # Persistent storage
+    persistentVolume:
+      enabled: true
+      size: 100Gi
+      storageClass: "gp3"
+    # Retention policy
+    retention: "30d"
+    # Resource allocation
+    resources:
+      limits:
+        cpu: "2000m"
+        memory: "4096Mi"
+      requests:
+        cpu: "1000m"
+        memory: "2048Mi"
+    # Security - internal access only
+    service:
+      type: ClusterIP
 ```
 
 ### Resource Requirements
@@ -265,8 +270,11 @@ kubectl exec -it deployment/eoapi-obs-grafana -n eoapi -- \
 Enable alertmanager for alert management:
 
 ```yaml
+monitoring:
+  prometheus:
+    enabled: true
+
 prometheus:
-  enabled: true
   alertmanager:
     enabled: true
     config:
@@ -289,8 +297,11 @@ prometheus:
 Enable pushgateway for batch job metrics:
 
 ```yaml
+monitoring:
+  prometheus:
+    enabled: true
+
 prometheus:
-  enabled: true
   prometheus-pushgateway:
     enabled: true  # For batch job metrics collection
 ```

--- a/scripts/deployment.sh
+++ b/scripts/deployment.sh
@@ -183,7 +183,7 @@ EOF
 
     if is_ci; then
         log_info "Applying CI-specific configurations..."
-        helm_cmd="$helm_cmd --set monitoring.prometheusAdapter.prometheus.url=http://$RELEASE_NAME-prometheus-server.eoapi.svc.cluster.local"
+        helm_cmd="$helm_cmd --set prometheus-adapter.prometheus.url=http://$RELEASE_NAME-prometheus-server.$NAMESPACE.svc.cluster.local"
         testing_mode=true
     fi
 


### PR DESCRIPTION
- Nest `prometheusAdapter` under `monitoring` in the production profile and add per-service request-rate adapter rules
- Update HPA templates to use `eoapi.hpaRequestRateMetricName` helper for metric names
- Add autoscaling and production-profile unit tests for the new metric names