### PR TITLE
fix: disable mock OIDC server in core profile

### DIFF
--- a/charts/eoapi/profiles/core.yaml
+++ b/charts/eoapi/profiles/core.yaml
@@ -7,7 +7,9 @@
 #   helm upgrade eoapi ./charts/eoapi -f profiles/core.yaml
 
 # Core services only
-testing: false
+testing:
+  mockOidcServer:
+    enabled: false
 
 ######################
 # DATABASE

--- a/charts/eoapi/tests/profiles_core_test.yaml
+++ b/charts/eoapi/tests/profiles_core_test.yaml
@@ -1,0 +1,28 @@
+suite: core profile release tests
+templates:
+  - templates/_helpers/core.tpl
+  - templates/_helpers/services.tpl
+  - templates/_helpers/database.tpl
+  - templates/services/stac/deployment.yaml
+  - templates/services/stac/configmap.yaml
+  - templates/testing/deployment.yaml
+tests:
+  - it: core profile renders stac deployment
+    values:
+      - ../profiles/core.yaml
+    set:
+      gitSha: ABC123
+    template: templates/services/stac/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+
+  - it: core profile keeps testing infrastructure disabled
+    values:
+      - ../profiles/core.yaml
+    set:
+      gitSha: ABC123
+    template: templates/testing/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
- Replace `testing: false` with `testing.mockOidcServer.enabled: false` in core profile
- Add unit test verifying core profile renders STAC and keeps testing infra disabled