### PR TITLE
ci: run all helm unittest suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run Helm unit tests
         run: |
           helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
-          helm unittest charts/eoapi --color
+          helm unittest charts/eoapi -f 'tests/*_test.yaml' -f 'tests/*_tests.yaml' --color
 
       - name: Check container images for root user
         run: ./eoapi-cli test images

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -105,7 +105,7 @@ test_unit() {
         return 1
     fi
 
-    if helm unittest "$CHART_PATH"; then
+    if helm unittest "$CHART_PATH" -f 'tests/*_test.yaml' -f 'tests/*_tests.yaml' --color; then
         log_success "Unit tests passed"
     else
         log_error "Unit tests failed"


### PR DESCRIPTION
- Expand `helm unittest` in CI and `scripts/test.sh` to run both `*_test.yaml` and `*_tests.yaml` patterns
- Closes the gap where 11 legacy test suites were never executed in CI

**Merge after:**
- #547 (autoscaling test rename and new suites)
- #548 (legacy test suite fixes)

CI will fail on this PR until those land.