### PR TITLE
chore: bump version of kubernetes to 1.34+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## Prerequisites
 
-- Kubernetes cluster (1.30+)
+- Kubernetes cluster (1.34+)
 - Helm 3.x
 - `kubectl` configured for cluster access
 

--- a/charts/eoapi/Chart.yaml
+++ b/charts/eoapi/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eoapi
 description: Create a full Earth Observation API with Metadata, Raster and Vector services
 type: application
-kubeVersion: '>=1.30.0-0'
+kubeVersion: '>=1.34.0-0'
 icon: https://eoapi.dev/img/eoAPI.png
 annotations:
   artifacthub.io/changes: |

--- a/charts/eoapi/README.md
+++ b/charts/eoapi/README.md
@@ -36,7 +36,7 @@ helm install eoapi eoapi/eoapi -f profiles/experimental.yaml
 
 ## Prerequisites
 
-- Kubernetes 1.30+
+- Kubernetes 1.34+. We only support versions in the [official Kubernetes release cycle](https://kubernetes.io/releases/).
 - Helm 3.0+
 - PV provisioner support
 - PostgreSQL operator

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,6 +6,8 @@ external_links:
     url: "https://github.com/developmentseed/eoapi-k8s"
   - name: "Helm Documentation"
     url: "https://helm.sh/docs/"
+  - name: "Kubernetes Releases"
+    url: "https://kubernetes.io/releases/"
 ---
 
 # Quick Start
@@ -13,7 +15,7 @@ external_links:
 ## Prerequisites
 
 - [helm](https://helm.sh/docs/intro/install/)
-- A Kubernetes cluster (local or cloud-based)
+- A Kubernetes cluster on a version in the [official Kubernetes release cycle](https://kubernetes.io/releases/) (1.34+)
 - `kubectl` configured for your cluster (ensure `KUBECONFIG` environment variable is set to point to your cluster configuration file, or use `kubectl config use-context <your-context>` to set the active cluster)
 - [helm unittest](https://github.com/helm-unittest/helm-unittest?tab=readme-ov-file#install) if contributing to the repository and running `./eoapi-cli test unit`
 


### PR DESCRIPTION
Closes #561 

**Don't merge, yet**. This might  be first the commit that will lead to the release as `1.0.0` :tada: 

This bumps the Kubernetes to the latest of the [supported Kubernetes releases](https://kubernetes.io/releases/). In this case version `1.34` and higher.