### PR TITLE
fix: render shared ingress annotations as a merged map and guard nil browser.ingress

### DIFF
--- a/charts/eoapi/templates/_helpers/networking.tpl
+++ b/charts/eoapi/templates/_helpers/networking.tpl
@@ -56,14 +56,13 @@ Shared Traefik entrypoints and user annotations for ingress resources.
 */}}
 {{- define "eoapi.ingressCommonAnnotations" -}}
 {{- $root := . -}}
-{{- $ingressAnnotations := $root.Values.ingress.annotations | default dict -}}
-{{- if eq $root.Values.ingress.className "traefik" -}}
-{{- if and $root.Values.ingress.entrypoints (not (hasKey $ingressAnnotations "traefik.ingress.kubernetes.io/router.entrypoints")) -}}
-traefik.ingress.kubernetes.io/router.entrypoints: {{ $root.Values.ingress.entrypoints | quote }}
+{{- $annotations := dict -}}
+{{- if and (eq $root.Values.ingress.className "traefik") $root.Values.ingress.entrypoints -}}
+{{- $_ := set $annotations "traefik.ingress.kubernetes.io/router.entrypoints" ($root.Values.ingress.entrypoints | toString) -}}
 {{- end -}}
-{{- end -}}
-{{- if not (empty $ingressAnnotations) -}}
-{{- toYaml $ingressAnnotations -}}
+{{- $annotations = mergeOverwrite $annotations (deepCopy ($root.Values.ingress.annotations | default dict)) -}}
+{{- if not (empty $annotations) -}}
+{{- toYaml $annotations -}}
 {{- end -}}
 {{- end -}}
 
@@ -166,7 +165,7 @@ Return true when the browser should be exposed via its own ingress.
 Return the configured browser ingress path without trailing slash ("/" for a root path).
 */}}
 {{- define "eoapi.browserIngressPath" -}}
-{{- trimSuffix "/" (.Values.browser.ingress.path | default "/browser") | default "/" -}}
+{{- trimSuffix "/" ((((.Values.browser).ingress).path) | default "/browser") | default "/" -}}
 {{- end -}}
 
 {{/*

--- a/charts/eoapi/tests/ingress_test.yaml
+++ b/charts/eoapi/tests/ingress_test.yaml
@@ -75,6 +75,8 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: "traefik"
+      - notExists:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
 
   - it: "vector ingress with nginx controller"
     template: templates/networking/ingress.yaml
@@ -431,6 +433,26 @@ tests:
           path: spec.rules[0].http.paths[0].backend.service.name
           value: RELEASE-NAME-doc-server
 
+  - it: "docServer honors ingress.rootPath"
+    template: templates/networking/ingress.yaml
+    set:
+      ingress.enabled: true
+      ingress.className: "nginx"
+      ingress.rootPath: "docs"
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+      docServer.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: "/docs"
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-doc-server
+
   - it: "mockOidcServer with custom path"
     template: templates/networking/ingress.yaml
     set:
@@ -581,3 +603,35 @@ tests:
             - /stac
             - /raster
             - /multidim
+
+  - it: "renders no strip-prefix middleware when no path needs stripping"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.className: "traefik"
+      stac.enabled: true
+      stac.ingress.path: "/"
+      raster.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "excludes auth-proxied stac from strip-prefix prefixes"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      ingress.className: "traefik"
+      stac.enabled: true
+      stac-auth-proxy.enabled: true
+      raster.enabled: true
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - isKind:
+          of: Middleware
+      - equal:
+          path: spec.stripPrefix.prefixes
+          value:
+            - /raster

--- a/charts/eoapi/tests/ingress_test.yaml
+++ b/charts/eoapi/tests/ingress_test.yaml
@@ -200,6 +200,52 @@ tests:
             traefik.ingress.kubernetes.io/router.entrypoints: web
             traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
 
+  - it: "traefik entrypoints coexist with custom annotations"
+    template: templates/networking/ingress.yaml
+    set:
+      ingress.className: "traefik"
+      ingress.entrypoints: "websecure"
+      ingress.annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      ingress.host: "eoapi.local"
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.annotations
+          value:
+            traefik.ingress.kubernetes.io/router.entrypoints: websecure
+            cert-manager.io/cluster-issuer: "letsencrypt-prod"
+            traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
+
+  - it: "browser ingress combines entrypoints with custom annotations"
+    template: templates/networking/browser-ingress.yaml
+    set:
+      ingress.className: "traefik"
+      ingress.entrypoints: "websecure"
+      ingress.annotations:
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+      ingress.host: "eoapi.local"
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.entrypoints"]
+          value: websecure
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+
   - it: "all services enabled with custom paths"
     template: templates/networking/ingress.yaml
     set:

--- a/charts/eoapi/tests/stac_browser_tests.yaml
+++ b/charts/eoapi/tests/stac_browser_tests.yaml
@@ -42,6 +42,21 @@ tests:
           content:
             name: SB_pathPrefix
             value: "/stac-browser/"
+  - it: "stac browser deployment tolerates null browser ingress block"
+    set:
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.ingress: null
+    template: templates/services/browser/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SB_pathPrefix
+            value: "/browser/"
   - it: "stac browser deployment with root ingress path"
     set:
       raster.enabled: false


### PR DESCRIPTION
Follow-up to reviewing #546. Fixes two render bugs in the centralized ingress helpers (traefik `entrypoints` + custom `ingress.annotations` produced invalid YAML; `browser.ingress: null` crashed the browser Deployment render), with regression tests that fail on the current branch head.

The second commit adds pinning tests for guarantees the refactor delivers: 
1. the strip-prefix annotation/Middleware are only rendered when a path is stripped
2. the auth-proxied `/stac` path stays out of the strip-prefix list, 
3. `docServer` honors `ingress.rootPath`. 

For 1. , the middleware tests fail against the templates on `main`, so they seem to lock in exactly the dangling-middleware fix #546 introduces.
