### PR TITLE
fix: omit redundant Release.Namespace from resource metadata

### DIFF
--- a/charts/eoapi/templates/core/cloudevents-sink.yaml
+++ b/charts/eoapi/templates/core/cloudevents-sink.yaml
@@ -10,7 +10,6 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: eoapi-cloudevents-sink
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eoapi.labels" . | nindent 4 }}
     app.kubernetes.io/component: cloudevents-sink

--- a/charts/eoapi/templates/core/knative-init.yaml
+++ b/charts/eoapi/templates/core/knative-init.yaml
@@ -3,7 +3,6 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-knative-init
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eoapi.labels" . | nindent 4 }}
     app.kubernetes.io/component: knative-init

--- a/charts/eoapi/templates/core/sink-binding.yaml
+++ b/charts/eoapi/templates/core/sink-binding.yaml
@@ -10,7 +10,6 @@ apiVersion: sources.knative.dev/v1
 kind: SinkBinding
 metadata:
   name: eoapi-notifier-sink-binding
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eoapi.labels" . | nindent 4 }}
     app.kubernetes.io/component: sink-binding

--- a/charts/eoapi/templates/networking/traefik-middleware.yaml
+++ b/charts/eoapi/templates/networking/traefik-middleware.yaml
@@ -27,7 +27,6 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ .Release.Name }}-strip-prefix-middleware
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-ingress
 spec:
@@ -49,7 +48,6 @@ apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: {{ .Release.Name }}-browser-redirect-middleware
-  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-ingress
 spec:

--- a/charts/eoapi/templates/testing/deployment.yaml
+++ b/charts/eoapi/templates/testing/deployment.yaml
@@ -7,7 +7,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "eoapi.fullname" . }}-mock-oidc-server
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eoapi.labels" . | nindent 4 }}
     app.kubernetes.io/component: mock-oidc-server

--- a/charts/eoapi/templates/testing/service.yaml
+++ b/charts/eoapi/templates/testing/service.yaml
@@ -7,7 +7,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "eoapi.fullname" . }}-mock-oidc-server
-  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "eoapi.labels" . | nindent 4 }}
     app.kubernetes.io/component: mock-oidc-server


### PR DESCRIPTION
Don’t hardcode the Kubernetes namespace in each resource, let Helm put them where you installed the chart (`helm install -n …`), except where a reference must name the namespace (like RBAC subjects or SinkBinding targets).

That follows the [Helm convention on chart templates and namespaces](https://helm.sh/docs/chart_best_practices/conventions/#chart-templates-and-namespaces).