### PR TITLE
feat: add rbac.create toggle for optional RBAC resources

### DIFF
--- a/charts/eoapi/templates/core/rbac.yaml
+++ b/charts/eoapi/templates/core/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apiServices }}
+{{- if and .Values.rbac.create .Values.apiServices }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/eoapi/tests/rbac_tests.yaml
+++ b/charts/eoapi/tests/rbac_tests.yaml
@@ -1,0 +1,89 @@
+suite: rbac.create toggle
+templates:
+  - templates/_helpers/core.tpl
+  - templates/core/rbac.yaml
+  - templates/core/service-account.yaml
+tests:
+  - it: creates Role and RoleBinding by default when apiServices is set
+    template: templates/core/rbac.yaml
+    set:
+      apiServices:
+        - stac
+      knative:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: Role
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: RoleBinding
+
+  - it: creates ClusterRole resources when knative is enabled
+    template: templates/core/rbac.yaml
+    set:
+      apiServices:
+        - stac
+      knative:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: Role
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: ClusterRole
+      - documentIndex: 2
+        equal:
+          path: kind
+          value: ClusterRoleBinding
+      - documentIndex: 3
+        equal:
+          path: kind
+          value: RoleBinding
+
+  - it: skips all RBAC resources when rbac.create is false
+    template: templates/core/rbac.yaml
+    set:
+      rbac:
+        create: false
+      apiServices:
+        - stac
+      knative:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: still creates ServiceAccount when rbac.create is false
+    template: templates/core/service-account.yaml
+    set:
+      rbac:
+        create: false
+      serviceAccount:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ServiceAccount
+
+  - it: skips ServiceAccount when serviceAccount.create is false even if rbac.create is true
+    template: templates/core/service-account.yaml
+    set:
+      rbac:
+        create: true
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/eoapi/values.schema.json
+++ b/charts/eoapi/values.schema.json
@@ -36,6 +36,17 @@
         }
       }
     },
+    "rbac": {
+      "type": "object",
+      "description": "Role-based access control configuration",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether to create RBAC resources (Role, RoleBinding, ClusterRole, ClusterRoleBinding). Independent of serviceAccount.create."
+        }
+      }
+    },
     "service": {
       "type": "object",
       "required": [

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -20,6 +20,14 @@ serviceAccount:
   annotations: {}
   labels: {}
 
+#######################
+# RBAC
+#######################
+# rbac.create controls whether Role, RoleBinding, ClusterRole, and
+# ClusterRoleBinding resources are created. Independent of serviceAccount.create.
+rbac:
+  create: true
+
 ######################
 # SERVICE & INGRESS
 ######################


### PR DESCRIPTION
Operators can turn off the chart’s built-in permission rules (`rbac.create: false`) without also turning off the service account, and they stay on by default so nothing breaks.

That matches Helm’s [RBAC best practices](https://helm.sh/docs/chart_best_practices/rbac/): use a separate `rbac.create` switch (default `true`), independent of `serviceAccount.create`.