### PR TITLE
chore: commit Chart.lock and build dependencies from it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ "main" ]
 
 env:
-  HELM_VERSION: latest
+  HELM_VERSION: v3.18.3
   PGO_VERSION: "5.8.6"
 
 jobs:
@@ -42,8 +42,14 @@ jobs:
 
       - name: Run Helm unit tests
         run: |
-          helm dependency update charts/eoapi
-          helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
+          helm repo add eoapi-k8s https://devseed.com/eoapi-k8s/
+          helm repo add knative https://knative.github.io/operator
+          helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo update
+          helm dependency build charts/eoapi
+          helm plugin install https://github.com/helm-unittest/helm-unittest
           helm unittest charts/eoapi -f 'tests/*_test.yaml' -f 'tests/*_tests.yaml' --color
 
       - name: Test gitSha injection script

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Add Helm repos
         run: |
           helm repo add eoapi https://devseed.com/eoapi-k8s/
+          helm repo add knative https://knative.github.io/operator
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/

--- a/charts/eoapi/.gitignore
+++ b/charts/eoapi/.gitignore
@@ -1,2 +1,1 @@
 tmp/
-Chart.lock

--- a/charts/eoapi/Chart.lock
+++ b/charts/eoapi/Chart.lock
@@ -1,0 +1,27 @@
+dependencies:
+- name: postgrescluster
+  repository: https://devseed.com/eoapi-k8s/
+  version: 5.8.6
+- name: eoapi-notifier
+  repository: oci://ghcr.io/developmentseed/charts
+  version: 0.1.0
+- name: knative-operator
+  repository: https://knative.github.io/operator
+  version: v1.22.3
+- name: metrics-server
+  repository: https://kubernetes-sigs.github.io/metrics-server/
+  version: 3.13.1
+- name: prometheus
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 29.19.0
+- name: prometheus-adapter
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 5.3.0
+- name: grafana
+  repository: https://grafana.github.io/helm-charts
+  version: 10.5.15
+- name: stac-auth-proxy
+  repository: oci://ghcr.io/developmentseed/stac-auth-proxy/charts
+  version: 1.1.1
+digest: sha256:e604e1c8f992e4b4ee2345bed8f76db5118eb8f0921ffc27fb593acc53add6b8
+generated: "2026-07-23T17:30:58.114133185+02:00"

--- a/docs/release.md
+++ b/docs/release.md
@@ -24,6 +24,18 @@ Verify with:
 helm repo update && helm search repo eoapi --versions
 ```
 
+## Chart dependencies
+
+`charts/eoapi/Chart.lock` is committed so installs and CI resolve the same subchart versions. Exact versions stay pinned in `Chart.yaml`.
+
+To bump a dependency:
+
+1. Edit the version in `charts/eoapi/Chart.yaml`
+2. Run `helm dependency update charts/eoapi` (regenerates `Chart.lock` and downloads charts)
+3. Review and commit both `Chart.yaml` and `Chart.lock`
+
+Day-to-day local/CI workflows use `helm dependency build` against the lockfile. HTTPS chart repos must be added first (`helm repo add`); OCI dependencies do not need that. Prefer Helm 3.18.x for dependency updates; CI and release workflows pin `v3.18.3`.
+
 ## Postgrescluster
 
 When `charts/postgrescluster/Chart.yaml` version changes on `main`, a separate workflow packages and publishes that chart automatically. No release PR is required.

--- a/scripts/deployment.sh
+++ b/scripts/deployment.sh
@@ -113,8 +113,11 @@ run_deployment() {
     kubectl wait --for=condition=Available deployment/pgo --timeout=300s
 
     cd "$PROJECT_ROOT"
-    log_info "Updating Helm dependencies..."
-    helm dependency update charts/eoapi
+    log_info "Building Helm dependencies from Chart.lock..."
+    if ! ensure_chart_dependencies charts/eoapi; then
+        log_error "Failed to build Helm chart dependencies"
+        return 1
+    fi
 
     local helm_cmd="helm upgrade --install $RELEASE_NAME charts/eoapi -n $NAMESPACE --create-namespace"
     local testing_mode=false

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -82,6 +82,50 @@ check_requirements() {
     validate_tools "$@"
 }
 
+# Register HTTPS chart repos referenced by charts/eoapi/Chart.yaml.
+# helm dependency build requires these; OCI repos do not.
+# URLs must match Chart.lock repository fields exactly (including trailing slash).
+ensure_helm_chart_repos() {
+    helm repo add eoapi-k8s https://devseed.com/eoapi-k8s/ --force-update >/dev/null
+    helm repo add knative https://knative.github.io/operator --force-update >/dev/null
+    helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/ --force-update >/dev/null
+    helm repo add prometheus-community https://prometheus-community.github.io/helm-charts --force-update >/dev/null
+    helm repo add grafana https://grafana.github.io/helm-charts --force-update >/dev/null
+    helm repo update eoapi-k8s knative metrics-server prometheus-community grafana >/dev/null
+}
+
+# Prefer helm dependency build when Chart.lock is present so CI/local
+# installs resolve the same locked subchart versions. Fall back to update
+# only when no lockfile exists (first-time / incomplete checkout).
+ensure_chart_dependencies() {
+    local chart_path="${1:-}"
+
+    if [[ -z "$chart_path" ]]; then
+        log_error "Chart path required for ensure_chart_dependencies"
+        return 1
+    fi
+
+    log_debug "Ensuring Helm chart repositories are configured..."
+    if ! ensure_helm_chart_repos; then
+        log_warn "Helm repo setup failed, continuing anyway..."
+    fi
+
+    if [[ -f "$chart_path/Chart.lock" ]]; then
+        log_debug "Building Helm chart dependencies from Chart.lock..."
+        if ! helm dependency build "$chart_path" &>/dev/null; then
+            log_warn "Helm dependency build failed, continuing anyway..."
+            return 1
+        fi
+    else
+        log_debug "Updating Helm chart dependencies (no Chart.lock)..."
+        if ! helm dependency update "$chart_path" &>/dev/null; then
+            log_warn "Helm dependency update failed, continuing anyway..."
+            return 1
+        fi
+    fi
+    return 0
+}
+
 validate_cluster() {
     if ! kubectl cluster-info >/dev/null 2>&1; then
         log_error "Cannot connect to Kubernetes cluster"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -104,9 +104,7 @@ test_unit() {
     check_requirements helm || return 1
 
     log_debug "Updating Helm chart dependencies..."
-    if ! helm dependency update "$CHART_PATH" &>/dev/null; then
-        log_warn "Helm dependency update failed, continuing anyway..."
-    fi
+    ensure_chart_dependencies "$CHART_PATH" || true
 
     if ! helm plugin list 2>/dev/null | grep -q unittest; then
         log_error "Helm unittest plugin not installed"

--- a/scripts/test/images.sh
+++ b/scripts/test/images.sh
@@ -30,11 +30,9 @@ if [[ ! -f "$PROFILE_PATH" ]]; then
   exit 1
 fi
 
-# Update Helm dependencies if needed
-log_debug "Updating Helm chart dependencies..."
-if ! helm dependency update "$CHART_PATH" &>/dev/null; then
-  log_warn "Helm dependency update failed, continuing anyway..."
-fi
+# Build Helm dependencies from Chart.lock when present
+log_debug "Building Helm chart dependencies..."
+ensure_chart_dependencies "$CHART_PATH" || true
 
 rendered_yaml=$(helm template test-release "$CHART_PATH" \
   -f "$PROFILE_PATH" \


### PR DESCRIPTION
We save a Chart.lock list of exact subchart versions so everyone (and CI) installs the same dependencies every time, instead of re-picking them, which matches Helm’s guidance to keep dependency resolution reproducible for application charts ([Dependencies](https://helm.sh/docs/chart_best_practices/dependencies/), plus Helm’s lockfile/helm dependency build workflow).