### PR TITLE
chore: drop unused ingress pathType and cert-manager schema

### DIFF
--- a/charts/eoapi/profiles/core.yaml
+++ b/charts/eoapi/profiles/core.yaml
@@ -166,7 +166,6 @@ observability:
 ingress:
   enabled: true
   className: "nginx"
-  pathType: "Prefix"
   host: ""
   tls:
     enabled: false

--- a/charts/eoapi/profiles/experimental.yaml
+++ b/charts/eoapi/profiles/experimental.yaml
@@ -325,7 +325,6 @@ autoscaling:
 ingress:
   enabled: true
   className: "nginx"
-  pathType: "Prefix"
   host: "localhost"
   tls:
     enabled: false

--- a/charts/eoapi/profiles/local/minikube.yaml
+++ b/charts/eoapi/profiles/local/minikube.yaml
@@ -15,9 +15,6 @@
 # Minikube uses nginx as the default ingress controller
 ingress:
   className: "nginx"
-  annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
 
 ######################
 # POSTGRESQL RESOURCES

--- a/charts/eoapi/profiles/production.yaml
+++ b/charts/eoapi/profiles/production.yaml
@@ -344,12 +344,10 @@ knative:
 ingress:
   enabled: true
   className: "nginx"
-  pathType: "Prefix"
   host: "eoapi.example.com"  # CHANGE THIS to your domain
   tls:
     enabled: true
     secretName: eoapi-tls
-    # certManager: true  # Uncomment if using cert-manager
 
 ######################
 # SECURITY & RBAC

--- a/charts/eoapi/values.schema.json
+++ b/charts/eoapi/values.schema.json
@@ -73,7 +73,7 @@
             "nginx",
             "traefik"
           ],
-          "description": "Ingress controller class name"
+          "description": "Supported ingress controller class name (NGINX or Traefik only)"
         },
         "entrypoints": {
           "type": "string",
@@ -108,18 +108,6 @@
             "secretName": {
               "type": "string",
               "description": "TLS secret name"
-            },
-            "certManager": {
-              "type": "boolean",
-              "description": "Use cert-manager for TLS"
-            },
-            "certManagerIssuer": {
-              "type": "string",
-              "description": "cert-manager issuer to use"
-            },
-            "certManagerEmail": {
-              "type": "string",
-              "description": "Email address for cert-manager"
             }
           }
         }
@@ -569,6 +557,10 @@
             "enabled": {
               "type": "boolean",
               "description": "Enable ingress for browser"
+            },
+            "path": {
+              "type": "string",
+              "description": "Ingress path prefix for the browser service"
             }
           }
         },
@@ -791,6 +783,28 @@
             },
             "image": {
               "$ref": "#/definitions/containerImage"
+            },
+            "ingress": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Expose mock OIDC server via unified ingress"
+                },
+                "path": {
+                  "type": "string",
+                  "description": "Ingress path prefix for the mock OIDC server"
+                }
+              }
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "port": {
+                  "type": "integer",
+                  "description": "Service port for the mock OIDC server"
+                }
+              }
             }
           }
         }
@@ -920,6 +934,10 @@
             "enabled": {
               "type": "boolean",
               "description": "Enable ingress for this service"
+            },
+            "path": {
+              "type": "string",
+              "description": "Ingress path prefix for this service"
             }
           }
         },


### PR DESCRIPTION
- Remove dead `ingress.pathType` from profiles and unused `tls.certManager*` schema keys
- Drop redundant minikube rewrite annotations (chart already emits them)
- Add missing schema for `*.ingress.path`, `browser.ingress.path`, and `testing.mockOidcServer.ingress|service`