### PR TITLE
fix: tolerate null browser.service and browser.ingress

### DIFF
--- a/charts/eoapi/templates/networking/ingress.yaml
+++ b/charts/eoapi/templates/networking/ingress.yaml
@@ -12,13 +12,14 @@ Helper template for generating ingress paths
   (dict "key" "vector")
   (dict "key" "multidim")
   (dict "key" "browser" "defaultPath" "/browser" "hasOwnPort" true)
-  (dict "key" "mockOidcServer" "actualName" "mock-oidc-server" "hasOwnPort" true "config" .Values.testing.mockOidcServer)
+  (dict "key" "mockOidcServer" "actualName" "mock-oidc-server" "hasOwnPort" true "defaultPath" "/mock-oidc" "config" .Values.testing.mockOidcServer)
 -}}
 
 {{- range $services }}
   {{- $service := .config | default (index $root.Values .key) }}
   {{- if and $service $service.enabled (or (not $service.ingress) $service.ingress.enabled) }}
-    {{- $path := $service.ingress.path | default .defaultPath }}
+    {{- $ingress := $service.ingress | default dict }}
+    {{- $path := $ingress.path | default .defaultPath }}
     {{- $useAuthProxy := and .usesAuthProxy (index $root.Values "stac-auth-proxy" "enabled") }}
     {{- $stripPath := and (ne $path "/") (not $useAuthProxy) }}
     {{- $serviceName := .actualName | default .key }}

--- a/charts/eoapi/templates/networking/traefik-middleware.yaml
+++ b/charts/eoapi/templates/networking/traefik-middleware.yaml
@@ -5,7 +5,7 @@
   (dict "key" "vector")
   (dict "key" "multidim")
   (dict "key" "browser" "defaultPath" "/browser" "skipStripPrefix" true)
-  (dict "key" "mockOidcServer" "config" .Values.testing.mockOidcServer)
+  (dict "key" "mockOidcServer" "defaultPath" "/mock-oidc" "config" .Values.testing.mockOidcServer)
 -}}
 {{- $prefixes := list -}}
 
@@ -14,7 +14,8 @@
   {{- if and $service $service.enabled (or (not $service.ingress) $service.ingress.enabled) }}
     {{- $stripPath := not (or .skipStripPrefix (and .usesAuthProxy (index $.Values "stac-auth-proxy" "enabled"))) }}
     {{- if $stripPath }}
-      {{- $path := $service.ingress.path | default .defaultPath }}
+      {{- $ingress := $service.ingress | default dict }}
+      {{- $path := $ingress.path | default .defaultPath }}
       {{- if $path }}
         {{- $prefixes = append $prefixes $path }}
       {{- end }}
@@ -42,7 +43,8 @@ spec:
        Keep this condition in sync with the router annotation in ingress.yaml. */}}
 {{- $browser := .Values.browser }}
 {{- if and $browser $browser.enabled (or (not $browser.ingress) $browser.ingress.enabled) }}
-{{- $browserPath := trimSuffix "/" ($browser.ingress.path | default "/browser") }}
+{{- $browserIngress := $browser.ingress | default dict }}
+{{- $browserPath := trimSuffix "/" ($browserIngress.path | default "/browser") }}
 ---
 apiVersion: traefik.io/v1alpha1
 kind: Middleware

--- a/charts/eoapi/templates/services/browser/deployment.yaml
+++ b/charts/eoapi/templates/services/browser/deployment.yaml
@@ -41,13 +41,14 @@ spec:
               {{- if .Values.browser.authConfig }}
               value: {{ .Values.browser.authConfig | toJson | quote }}
               {{- else }}
+              {{- $browserIngress := .Values.browser.ingress | default dict }}
               value: |-
                 {
                   "type": "openIdConnect",
                   "openIdConnectUrl": "{{ .Values.browser.oidcDiscoveryUrl }}",
                   "oidcConfig": {
                     "client_id": "{{ .Values.browser.oidcClientId | default "test-client" }}",
-                    "redirect_uri": "{{ if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}{{ .Values.browser.ingress.path | default "/browser" | trimSuffix "/" }}/auth"
+                    "redirect_uri": "{{ if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}{{ $browserIngress.path | default "/browser" | trimSuffix "/" }}/auth"
                   }
                 }
               {{- end }}

--- a/charts/eoapi/templates/services/browser/service.yaml
+++ b/charts/eoapi/templates/services/browser/service.yaml
@@ -16,6 +16,7 @@ spec:
     app: {{ .Release.Name }}-browser
   ports:
     - protocol: TCP
-      port: {{ .Values.browser.service.port | default 8080 }}
-      targetPort: {{ .Values.browser.service.port | default 8080 }}
+      {{- $browserService := .Values.browser.service | default dict }}
+      port: {{ $browserService.port | default 8080 }}
+      targetPort: {{ $browserService.port | default 8080 }}
 {{- end }}

--- a/charts/eoapi/tests/browser_redirect_test.yaml
+++ b/charts/eoapi/tests/browser_redirect_test.yaml
@@ -44,6 +44,24 @@ tests:
           path: spec.redirectRegex.replacement
           value: "${1}/stac-browser/"
 
+  - it: "tolerates null browser.ingress for the redirect middleware"
+    template: templates/networking/traefik-middleware.yaml
+    set:
+      browser.enabled: true
+      browser.ingress: null
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-browser-redirect-middleware
+      - equal:
+          path: spec.redirectRegex.regex
+          value: "^(https?://[^/]+)/browser$"
+      - equal:
+          path: spec.redirectRegex.replacement
+          value: "${1}/browser/"
+
   - it: "still renders the redirect middleware for a root browser path so the router reference never dangles"
     template: templates/networking/traefik-middleware.yaml
     set:

--- a/charts/eoapi/tests/ingress_test.yaml
+++ b/charts/eoapi/tests/ingress_test.yaml
@@ -405,6 +405,29 @@ tests:
             cert-manager.io/cluster-issuer: "letsencrypt-prod"
             nginx.ingress.kubernetes.io/rate-limit: "100"
 
+  - it: "mockOidcServer without ingress block falls back to default path"
+    set:
+      ingress.enabled: true
+      ingress.className: "nginx"
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+      testing.mockOidcServer.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: "/mock-oidc(/|$)(.*)"
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-mock-oidc-server
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 8080
+
   - it: "traefik entrypoints coexist with custom annotations"
     template: templates/networking/ingress.yaml
     set:

--- a/charts/eoapi/tests/stac_browser_tests.yaml
+++ b/charts/eoapi/tests/stac_browser_tests.yaml
@@ -47,6 +47,26 @@ tests:
       - equal:
           path: metadata.annotations.annotation2
           value: world
+
+  - it: "stac browser service tolerates null browser.service"
+    set:
+      raster.enabled: false
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.service: null
+    template: templates/services/browser/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8080
+
   - it: "stac browser deployment with auth enabled"
     set:
       raster.enabled: false
@@ -108,6 +128,36 @@ tests:
               {
                 "type": "openIdConnect",
                 "openIdConnectUrl": "https://auth.example.com/.well-known/openid-configuration",
+                "oidcConfig": {
+                  "client_id": "test-client",
+                  "redirect_uri": "http://localhost/browser/auth"
+                }
+              }
+  - it: "stac browser deployment with auth tolerates null browser.ingress"
+    set:
+      raster.enabled: false
+      stac.enabled: true
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: true
+      browser.ingress: null
+      stac-auth-proxy.enabled: true
+      ingress.host: "localhost"
+      stac.ingress.path: "/stac"
+      browser.oidcClientId: "test-client"
+      browser.oidcDiscoveryUrl: "http://localhost/mock-oidc/.well-known/openid-configuration"
+    template: templates/services/browser/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SB_authConfig
+            value: |-
+              {
+                "type": "openIdConnect",
+                "openIdConnectUrl": "http://localhost/mock-oidc/.well-known/openid-configuration",
                 "oidcConfig": {
                   "client_id": "test-client",
                   "redirect_uri": "http://localhost/browser/auth"


### PR DESCRIPTION
- Nil-safe `browser.service.port` and `*.ingress.path` access in Service, ingress paths, and Traefik middleware
- Default mockOidc ingress path `/mock-oidc` when the ingress block is omitted
- Unit tests for null `browser.service`, null `browser.ingress`, and mockOidc fallback