### PR TITLE
fix: keep chart rewrite and middleware annotations above user overrides

### DIFF
--- a/charts/eoapi/templates/networking/ingress.yaml
+++ b/charts/eoapi/templates/networking/ingress.yaml
@@ -72,6 +72,26 @@ Helper template for generating ingress paths
 
 {{- if and .Values.ingress.enabled (include "eoapi.hasEnabledService" . | trim | eq "true") }}
 {{- $ingressAnnotations := .Values.ingress.annotations | default dict }}
+{{- $annotations := dict }}
+{{- if and (eq .Values.ingress.className "traefik") .Values.ingress.entrypoints }}
+{{- $_ := set $annotations "traefik.ingress.kubernetes.io/router.entrypoints" (.Values.ingress.entrypoints | toString) }}
+{{- end }}
+{{- $annotations = mergeOverwrite $annotations $ingressAnnotations }}
+{{- if eq .Values.ingress.className "nginx" }}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/rewrite-target" "/$2" }}
+{{- $_ := set $annotations "nginx.ingress.kubernetes.io/use-regex" "true" }}
+{{- end }}
+{{- if eq .Values.ingress.className "traefik" }}
+{{- /* strip-prefix always; also chain the browser bare-path redirect when the browser ingress is on.
+       Keep this condition in sync with the redirect Middleware in traefik-middleware.yaml. */}}
+{{- $mwPrefix := printf "%s-%s" .Release.Namespace .Release.Name }}
+{{- $middlewares := list (printf "%s-strip-prefix-middleware@kubernetescrd" $mwPrefix) }}
+{{- $browser := .Values.browser }}
+{{- if and $browser $browser.enabled (or (not $browser.ingress) $browser.ingress.enabled) }}
+{{- $middlewares = append $middlewares (printf "%s-browser-redirect-middleware@kubernetescrd" $mwPrefix) }}
+{{- end }}
+{{- $_ := set $annotations "traefik.ingress.kubernetes.io/router.middlewares" (join "," $middlewares) }}
+{{- end }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
@@ -84,28 +104,10 @@ metadata:
   name: {{ .Release.Name }}-ingress
   labels:
     app: {{ .Release.Name }}-ingress
+  {{- with $annotations }}
   annotations:
-    {{- if eq .Values.ingress.className "nginx" }}
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- end }}
-    {{- if eq .Values.ingress.className "traefik" }}
-    {{- if and .Values.ingress.entrypoints (not (hasKey $ingressAnnotations "traefik.ingress.kubernetes.io/router.entrypoints")) }}
-    traefik.ingress.kubernetes.io/router.entrypoints: {{ .Values.ingress.entrypoints | quote }}
-    {{- end }}
-    {{- /* strip-prefix always; also chain the browser bare-path redirect when the browser ingress is on.
-           Keep this condition in sync with the redirect Middleware in traefik-middleware.yaml. */}}
-    {{- $mwPrefix := printf "%s-%s" .Release.Namespace .Release.Name }}
-    {{- $middlewares := list (printf "%s-strip-prefix-middleware@kubernetescrd" $mwPrefix) }}
-    {{- $browser := .Values.browser }}
-    {{- if and $browser $browser.enabled (or (not $browser.ingress) $browser.ingress.enabled) }}
-    {{- $middlewares = append $middlewares (printf "%s-browser-redirect-middleware@kubernetescrd" $mwPrefix) }}
-    {{- end }}
-    traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $middlewares }}
-    {{- end }}
-    {{- with $ingressAnnotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/eoapi/tests/ingress_test.yaml
+++ b/charts/eoapi/tests/ingress_test.yaml
@@ -428,6 +428,42 @@ tests:
             cert-manager.io/cluster-issuer: "letsencrypt-prod"
             traefik.ingress.kubernetes.io/router.middlewares: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
 
+  - it: "traefik chart middlewares win over user router.middlewares annotation"
+    set:
+      ingress.className: "traefik"
+      ingress.annotations:
+        traefik.ingress.kubernetes.io/router.middlewares: custom-auth@kubernetescrd
+      ingress.host: "eoapi.local"
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - equal:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          value: NAMESPACE-RELEASE-NAME-strip-prefix-middleware@kubernetescrd
+
+  - it: "nginx chart rewrite annotations win over user rewrite-target/use-regex"
+    set:
+      ingress.className: "nginx"
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /custom
+        nginx.ingress.kubernetes.io/use-regex: "false"
+      ingress.host: "eoapi.local"
+      raster.enabled: true
+      stac.enabled: false
+      vector.enabled: false
+      multidim.enabled: false
+      browser.enabled: false
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/rewrite-target"]
+          value: /$2
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/use-regex"]
+          value: "true"
+
   - it: "docServer honors ingress.rootPath"
     template: templates/networking/ingress.yaml
     set:

--- a/charts/eoapi/values.yaml
+++ b/charts/eoapi/values.yaml
@@ -49,7 +49,7 @@ ingress:
   host: ""
   # Multiple host domains array - if specified, takes precedence over single host
   # hosts: []
-  # Custom annotations to add to the ingress
+  # Custom annotations (chart owns rewrite-target/use-regex/router.middlewares)
   annotations: {}
   # TLS configuration
   tls:

--- a/docs/unified-ingress.md
+++ b/docs/unified-ingress.md
@@ -44,7 +44,7 @@ ingress:
   rootPath: ""        # Root path for doc server
   host: ""            # Single host (or use hosts array)
   hosts: []           # Multiple hosts (takes precedence over host)
-  annotations: {}     # Custom annotations
+  annotations: {}     # Custom annotations (chart owns rewrite-target/use-regex/router.middlewares)
   tls:
     enabled: false
     secretName: eoapi-tls
@@ -123,7 +123,11 @@ ingress:
 ```
 
 If you set the same annotation via `ingress.annotations`, it overrides `ingress.entrypoints`
-because user annotations are rendered after the chart defaults.
+because user annotations are rendered after the chart defaults. Only path-rewrite annotations
+are chart-owned and always win over `ingress.annotations`:
+`nginx.ingress.kubernetes.io/rewrite-target`, `nginx.ingress.kubernetes.io/use-regex`, and
+`traefik.ingress.kubernetes.io/router.middlewares`. Setting those keys in `ingress.annotations`
+has no effect.
 
 ### Path Handling Details
 


### PR DESCRIPTION
- Merge ingress annotations as a map so chart-owned rewrite/middleware keys win over `ingress.annotations`
- User override of Traefik `router.entrypoints` still works
- Unit test: chart middlewares win over user `router.middlewares`

Note: anyone who intentionally overrode rewrite-target or router.middlewares via `ingress.annotations` will need to use another mechanism after this.